### PR TITLE
bug 103561 - Update OpenSSL version

### DIFF
--- a/zimbra/osl/zimbra-osl/debian/changelog
+++ b/zimbra/osl/zimbra-osl/debian/changelog
@@ -1,6 +1,7 @@
 zimbra-osl (1.0.4-ITERATIONZAPPEND) unstable; urgency=low
 
   * Update rsync to 3.1.2
+  * Update openssl to 1.0.1r
 
  -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 27 Jan 2016 00:00:00 +0000
 

--- a/zimbra/osl/zimbra-osl/open_source_licenses.txt
+++ b/zimbra/osl/zimbra-osl/open_source_licenses.txt
@@ -75,7 +75,7 @@ SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
    >>> nviennot-nginx-tcp-keepalive-4d7186d
    >>> opendkim-2.10.3
    >>> openldap-2.4.43
-   >>> openssl-1.0.1q
+   >>> openssl-1.0.1r
    >>> owasp-java-html-sanitizer.jar-r239
    >>> perl-data-uuid-1.221
    >>> perl-geography-countries-2009041301
@@ -4676,7 +4676,7 @@ California, USA.  All Rights Reserved.  Permission to copy and
 distribute verbatim copies of this document is granted.
 
 
->>> openssl-1.0.1q
+>>> openssl-1.0.1r
 
 LICENSE ISSUES
   ==============
@@ -22327,7 +22327,7 @@ ADDITIONAL LICENSE INFORMATION:
 >  MIT
 
 
-\rsync-3.0.9.tar.gz\rsync-3.0.9.tar\rsync-3.0.9\zlib\zlib.h
+rsync-3.1.2/zlib/zlib.h
 
 
 Copyright (C) 1995-2005 Jean-loup Gailly and Mark Adler

--- a/zimbra/osl/zimbra-osl/rpm/SPECS/osl.spec
+++ b/zimbra/osl/zimbra-osl/rpm/SPECS/osl.spec
@@ -17,6 +17,7 @@ software used by Zimbra
 %changelog
 * Wed Jan 27 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4
 - Update rsync to 3.1.2
+- Update openssl to 1.0.1r
 * Mon Jan 11 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3
 - Update MariaDB to 10.1.10
 - Update Selenium to 2.49.0


### PR DESCRIPTION
Bump OpenSSL version
Tweak rsync bits for additional 3rd party license to current version.  Fix windows based formatting from old license generation system.