### PR TITLE
bug 103109 - Build with optimization level 0

### DIFF
--- a/thirdparty/nginx/zimbra-nginx/debian/rules
+++ b/thirdparty/nginx/zimbra-nginx/debian/rules
@@ -3,6 +3,8 @@ export DEB_BUILD_OPTIONS=nocheck
 
 # Ensure rpath is set correctly
 export DEB_LDFLAGS_MAINT_APPEND=-Wl,-rpath,OZCL
+export DEB_CFLAGS_MAINT_STRIP=-O2
+export DEB_CFLAGS_MAINT_APPEND=-O0
 
 %:
 	dh $@

--- a/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
+++ b/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
@@ -27,7 +27,7 @@ The Zimbra nginx build
 
 %build
 LDFLAGS="-Wl,-rpath,OZCL"; export LDFLAGS; \
-CFLAGS="-g -O2"; export CFLAGS; \
+CFLAGS="-g -O0"; export CFLAGS; \
 ./configure --prefix=OZC \
   --with-cc-opt="-g -IOZCI" \
   --with-ld-opt="-Wl,-rpath,OZCL -LOZCL" \


### PR DESCRIPTION
As it turns out, building nginx with -O2 causes our lookup
extensions to fail.  More work is needed to determing the reason for
this, but for now, compiling without -O2 enables our lookup code
to function correctly.