### PR TITLE
bug 103955 - Update cacerts package to install cacerts into /opt/zimb…

### DIFF
--- a/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/changelog
+++ b/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-openjdk-cacerts (1.0.5-ITERATIONZAPPEND) unstable; urgency=low
+
+  * Relocate cacerts to OZCE/java to avoid conflicts with the OpenJDK package
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Thu, 11 Feb 2016 00:00:00 +0000
+
 zimbra-openjdk-cacerts (1.0.4-ITERATIONZAPPEND) unstable; urgency=low
 
   * Support running zmcertmgr as user zimbra instead of root

--- a/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/rules
+++ b/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/rules
@@ -8,5 +8,5 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 
 override_dh_auto_install:
-	mkdir -p $(CURDIR)/debian/$(shell dh_listpackages)/OZCL/jvm/java/jre/lib/security/
-	cp cacerts $(CURDIR)/debian/$(shell dh_listpackages)/OZCL/jvm/java/jre/lib/security/
+	mkdir -p $(CURDIR)/debian/$(shell dh_listpackages)/OZCE/java
+	cp cacerts $(CURDIR)/debian/$(shell dh_listpackages)/OZCE/java

--- a/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/zimbra-openjdk-cacerts.postinst
+++ b/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/zimbra-openjdk-cacerts.postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ "$1" = configure ]; then
-  /bin/chown zimbra:zimbra /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts
-  /bin/chmod 644 /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts
+  /bin/chown zimbra:zimbra /opt/zimbra/common/etc/java/cacerts
+  /bin/chmod 644 /opt/zimbra/common/etc/java/cacerts
   if [ "$2" != "" ]; then
     if [ -x /opt/zimbra/bin/zmcertmgr ]; then
       # Run as zimbra, extract CA to /opt/zimbra/conf/ca

--- a/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/zimbra-openjdk-cacerts.preinst
+++ b/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/debian/zimbra-openjdk-cacerts.preinst
@@ -3,7 +3,7 @@ if [ "$1" = upgrade ]; then
   if [ x"$2" != "x" ]; then
     mkdir -p /opt/zimbra/.saveconfig/zimbra-openjdk-cacerts-$2
     cacerts=`mktemp --tmpdir=/opt/zimbra/.saveconfig/zimbra-openjdk-cacerts-$2 cacerts.XXXXXX 2>/dev/null`
-    cp /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts $cacerts
+    cp /opt/zimbra/common/etc/java/cacerts $cacerts
   fi
 fi
 exit 0

--- a/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/rpm/SPECS/openjdk-cacerts.spec
+++ b/thirdparty/openjdk-cacerts/zimbra-openjdk-cacerts/rpm/SPECS/openjdk-cacerts.spec
@@ -1,6 +1,6 @@
 Summary:            CA Certs keystore for OpenJDK
 Name:               zimbra-openjdk-cacerts
-Version:            1.0.4
+Version:            1.0.5
 Release:            ITERATIONZAPPEND
 License:            MPL-2
 Requires:           zimbra-base, zimbra-openjdk
@@ -13,24 +13,37 @@ AutoReqProv:        no
 %description
 CA certs keystore for use with OpenJDK
 
+%changelog
+* Thu Feb 11 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.5-ITERATIONZAPPEND
+- Relocate cacerts to OZCE/java to avoid conflicts with the OpenJDK package
+* Fri Dec 14 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4-ITERATIONZAPPEND
+- Support running zmcertmgr as user zimbra instead of root
+* Fri Dec 11 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3-ITERATIONZAPPEND
+- Enhance upgrade check
+* Mon Dec 07 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.2-ITERATIONZAPPEND
+- Ensure that on upgrades of the zimbra-openjdk-cacerts package, that the keystore is updated
+- Ensure that on upgrades of the zimbra-openjdk-cacerts package, that the old keystore is backed up
+* Wed Dec 02 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.1-ITERATIONZAPPEND
+- Updated to include full CA Certs from Mozilla CA list
+
 %install
-mkdir -p ${RPM_BUILD_ROOT}/OZCL/jvm/java/jre/lib/security/
-cp ../../cacerts ${RPM_BUILD_ROOT}/OZCL/jvm/java/jre/lib/security/cacerts
+mkdir -p ${RPM_BUILD_ROOT}/OZCE/java
+cp ../../cacerts ${RPM_BUILD_ROOT}/OZCE/java/cacerts
 
 %files
-OZCL/jvm/java/jre/lib/security
+%attr(644,zimbra,zimbra) OZCE/java/cacerts
 
 %pre -p /bin/bash
 if [ "$1" -ge "2" ]; then
   zver=$(rpm -q --queryformat='%%{version}-%%{release}' zimbra-openjdk-cacerts)
   mkdir -p /opt/zimbra/.saveconfig/zimbra-openjdk-cacerts-${zver}
   cacerts=`mktemp --tmpdir=/opt/zimbra/.saveconfig/zimbra-openjdk-cacerts-${zver} cacerts.XXXXXX`
-  cp /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts $cacerts
+  cp OZCE/java/cacerts $cacerts
 fi
 
 %post -p /bin/bash
-/bin/chown zimbra:zimbra /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts
-/bin/chmod 644 /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts
+/bin/chown zimbra:zimbra OZCE/java/cacerts
+/bin/chmod 644 OZCE/java/cacerts
 if [ "$1" -ge "2" ]; then
   if [ -x /opt/zimbra/bin/zmcertmgr ]; then
     # Run as zimbra, extract CA to /opt/zimbra/conf/ca
@@ -40,13 +53,3 @@ if [ "$1" -ge "2" ]; then
   fi
 fi
 
-%changelog
-* Fri Dec 14 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4
-- Support running zmcertmgr as user zimbra instead of root
-* Fri Dec 11 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3
-- Enhance upgrade check
-* Mon Dec 07 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.2
-- Ensure that on upgrades of the zimbra-openjdk-cacerts package, that the keystore is updated
-- Ensure that on upgrades of the zimbra-openjdk-cacerts package, that the old keystore is backed up
-* Wed Dec 02 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.1
-- Updated to include full CA Certs from Mozilla CA list

--- a/thirdparty/openjdk/zimbra-openjdk/debian/changelog
+++ b/thirdparty/openjdk/zimbra-openjdk/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-openjdk (VERSION-1zimbra8.7b2ZAPPEND) unstable; urgency=medium
+
+  * Fix cacerts handling to avoid conflicts
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 1 May 2015 22:26:24 +0000
+
 zimbra-openjdk (VERSION-ITERATIONZAPPEND) unstable; urgency=medium
 
   * Initial Release.

--- a/thirdparty/openjdk/zimbra-openjdk/debian/rules
+++ b/thirdparty/openjdk/zimbra-openjdk/debian/rules
@@ -27,6 +27,8 @@ override_dh_auto_install:
 	rm -rf $(CURDIR)/debian/tmp/OZCL/jvm/java/demo
 	rm -rf $(CURDIR)/debian/tmp/OZCL/jvm/java/sample
 	rm -f $(CURDIR)/debian/tmp/OZCL/jvm/java/jre/lib/security/cacerts
+	cd $(CURDIR)/debian/tmp/OZCL/jvm/java/jre/lib/security && \
+	ln -s OZCE/java/cacerts cacerts
 	cd $(CURDIR)/debian/tmpOZCB && ln -s ../lib/jvm/java/bin/jar
 	cd $(CURDIR)/debian/tmpOZCB && ln -s ../lib/jvm/java/bin/java
 	cd $(CURDIR)/debian/tmpOZCB && ln -s ../lib/jvm/java/bin/javac

--- a/thirdparty/openjdk/zimbra-openjdk/rpm/SPECS/openjdk.spec
+++ b/thirdparty/openjdk/zimbra-openjdk/rpm/SPECS/openjdk.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's OpenJDK build
 Name:               zimbra-openjdk
 Version:            VERSION
-Release:            ITERATIONZAPPEND
+Release:            1zimbra8.7b2ZAPPEND
 License:            GPL-2
 Source:             %{name}-%{version}.tgz
 BuildRequires:      zip, libX11-devel, libXau-devel, libXext-devel, libXfixes-devel
@@ -17,6 +17,10 @@ URL:                http://openjdk.java.net/
 
 %description
 The Zimbra OpenJDK build
+
+%changelog
+* Thu Feb 11 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b2ZAPPEND
+- Fix cacerts handling to avoid conflicts
 
 %prep
 %setup -n openjdk-%{version}
@@ -41,6 +45,8 @@ ln -s openjdk* java
 rm -rf java/demo
 rm -rf java/sample
 rm -f java/jre/lib/security/cacerts
+cd java/jre/lib/security
+ln -s OZCE/java/cacerts cacerts
 cd ${RPM_BUILD_ROOT}OZCB
 ln -s ../lib/jvm/java/bin/jar
 ln -s ../lib/jvm/java/bin/java


### PR DESCRIPTION
Update cacerts package to install cacerts into /opt/zimbra/common/etc/java.  Update openjdk package to create a symlink to the cacerts file.

Confirmed packages generate what is expected:
build@c687:~/git/87/packages/thirdparty/openjdk/tmp/RHEL6_64/zimbra-openjdk/rpm/RPMS/x86_64$ rpm -qlpv zimbra-openjdk-1.8.0u74b02-1zimbra8.7b2.el6.x86_64.rpm | grep cacerts
lrwxrwxrwx    1 root    root                       35 Feb 11 19:39 /opt/zimbra/common/lib/jvm/openjdk-1.8.0_74-zimbra/jre/lib/security/cacerts -> /opt/zimbra/common/etc/java/cacerts

dpkg -c zimbra-openjdk_1.8.0u74b02-1zimbra8.7b2.14.04_amd64.deb
lrwxrwxrwx root/root         0 2016-02-12 00:38 ./opt/zimbra/common/lib/jvm/openjdk-1.8.0_74-zimbra/jre/lib/security/cacerts -> ../../../../../../etc/java/cacerts
