### PR TITLE
Extract platform specifica into separate def files

### DIFF
--- a/package-RHEL.def
+++ b/package-RHEL.def
@@ -1,14 +1,4 @@
-PKG_BUILD := rpmbuild -v --define "_topdir $$PWD" -ba
-PKG_EXT := rpm
-PKG_EXTRACT := sudo yum -y install
-PKG_PURGE := sudo yum erase -y
-PKG_DEV := devel
-PKG_LIB := libs
+include $(THIRDPARTY_ROOT)/package-rpm.def
 
-ifeq ($(BUILD_PLATFORM), RHEL6_64)
-	PKG_APPEND := .el6
-else ifeq ($(BUILD_PLATFORM), RHEL7_64)
-	PKG_APPEND := .el7
-else
-	PKG_APPEND := $(error unsupported BUILD_PLATFORM $(BUILD_PLATFORM))
-endif
+PKG_APPEND.RHEL7_64 = .el7
+PKG_APPEND.RHEL6_64 = .el6

--- a/package-UBUNTU.def
+++ b/package-UBUNTU.def
@@ -1,16 +1,5 @@
-PKG_BUILD := dpkg-buildpackage -irpm
-PKG_EXT := deb
-PKG_EXTRACT := sudo apt-get install -y
-PKG_PURGE := sudo apt-get -y --purge purge
-PKG_DEV := dev
-PKG_LIB	:= lib
+include $(THIRDPARTY_ROOT)/package-deb.def
 
-ifeq ($(BUILD_PLATFORM), UBUNTU12_64)
-	PKG_APPEND := .12.04
-else ifeq ($(BUILD_PLATFORM), UBUNTU14_64)
-	PKG_APPEND := .14.04
-else ifeq ($(BUILD_PLATFORM), UBUNTU16_64)
-	PKG_APPEND := .16.04
-else
-	PKG_APPEND := $(error unsupported BUILD_PLATFORM $(BUILD_PLATFORM))
-endif
+PKG_APPEND.UBUNTU16_64 := .16.04
+PKG_APPEND.UBUNTU14_64 := .14.04
+PKG_APPEND.UBUNTU12_64 := .12.04

--- a/package-deb.def
+++ b/package-deb.def
@@ -1,0 +1,7 @@
+PKG_EXT := deb
+
+PKG_BUILD := dpkg-buildpackage -irpm
+PKG_EXTRACT := sudo apt-get --assume-yes --verbose-versions install
+PKG_PURGE := sudo apt-get --assume-yes --purge purge
+PKG_DEV := dev
+PKG_LIB := lib

--- a/package-rpm.def
+++ b/package-rpm.def
@@ -1,0 +1,7 @@
+PKG_EXT := rpm
+
+PKG_BUILD := rpmbuild -v --define "_topdir $$PWD" -ba
+PKG_EXTRACT := sudo yum -y install
+PKG_PURGE := sudo yum erase -y
+PKG_DEV := devel
+PKG_LIB := libs

--- a/package.def
+++ b/package.def
@@ -65,6 +65,7 @@ ifneq ($(wildcard $(THIRDPARTY_ROOT)/package-$(BUILD_DISTRIBUTION).def), )
 else
 	include $(error unsupported BUILD_PLATFORM $(BUILD_PLATFORM))
 endif
+PKG_APPEND ?= $(PKG_APPEND.$(BUILD_PLATFORM))
 
 # Platform specific package overrides
 ifneq ($(wildcard $(PKG_ROOT)/$(BUILD_DISTRIBUTION).def), )

--- a/package.def
+++ b/package.def
@@ -66,6 +66,14 @@ else
 	include $(error unsupported BUILD_PLATFORM $(BUILD_PLATFORM))
 endif
 
+# Platform specific package overrides
+ifneq ($(wildcard $(PKG_ROOT)/$(BUILD_DISTRIBUTION).def), )
+	include $(PKG_ROOT)/$(BUILD_DISTRIBUTION).def
+endif
+ifneq ($(wildcard $(PKG_ROOT)/$(BUILD_PLATFORM).def), )
+	include $(PKG_ROOT)/$(BUILD_PLATFORM).def
+endif
+
 PKG_MAINTAINER = Zimbra Packaging Services <packaging-devel@zimbra.com>
 
 define generic-setup

--- a/package.def
+++ b/package.def
@@ -52,11 +52,18 @@ PKG_REVISION = zimbra$(MAJOR).$(MINOR)b$(PKG_REVNUM)
 PKG_ITERATION = 1$(PKG_REVISION)
 
 # Platform specific:
-# - PKG_EXT deb|rpm
-ifeq (RHEL,$(findstring RHEL,$(BUILD_PLATFORM)))
-	include $(THIRDPARTY_ROOT)/package-RHEL.def
-else ifeq (UBUNTU,$(findstring UBUNTU,$(BUILD_PLATFORM)))
-	include $(THIRDPARTY_ROOT)/package-UBUNTU.def
+# - PKG_BUILD
+# - PKG_EXT
+# - PKG_EXTRACT
+# - PKG_PURGE
+# - PKG_DEV
+# - PKG_LIB
+# - PKG_APPEND
+BUILD_DISTRIBUTION := $(shell $(SED) -e 's/[0-9]*_[0-9]*$$//' <<< $(BUILD_PLATFORM))
+ifneq ($(wildcard $(THIRDPARTY_ROOT)/package-$(BUILD_DISTRIBUTION).def), )
+	include $(THIRDPARTY_ROOT)/package-$(BUILD_DISTRIBUTION).def
+else
+	include $(error unsupported BUILD_PLATFORM $(BUILD_PLATFORM))
 endif
 
 PKG_MAINTAINER = Zimbra Packaging Services <packaging-devel@zimbra.com>

--- a/thirdparty/perl-bit-vector/Makefile
+++ b/thirdparty/perl-bit-vector/Makefile
@@ -22,7 +22,6 @@ $(psrc_file):
 	$(MKDIR) $(@D) && $(CD) $(@D) && $(WGET) $(purl)
 
 storable = $(storable.$(BUILD_PLATFORM))
-storable.RHEL6_64 := zimbra-perl-storable
 
 pkgadd:
 	$(PKG_EXTRACT) zimbra-perl-base zimbra-perl-carp-clan $(storable)

--- a/thirdparty/perl-bit-vector/RHEL6_64.def
+++ b/thirdparty/perl-bit-vector/RHEL6_64.def
@@ -1,0 +1,1 @@
+storable.RHEL6_64 := zimbra-perl-storable

--- a/thirdparty/perl-date-calc/Makefile
+++ b/thirdparty/perl-date-calc/Makefile
@@ -22,7 +22,6 @@ $(psrc_file):
 	$(MKDIR) $(@D) && $(CD) $(@D) && $(WGET) $(purl)
 
 storable = $(storable.$(BUILD_PLATFORM))
-storable.RHEL6_64 := zimbra-perl-storable
 
 pkgadd:
 	$(PKG_EXTRACT) zimbra-perl-base zimbra-perl-carp-clan zimbra-perl-bit-vector

--- a/thirdparty/perl-date-calc/RHEL6_64.def
+++ b/thirdparty/perl-date-calc/RHEL6_64.def
@@ -1,0 +1,1 @@
+storable.RHEL6_64 := zimbra-perl-storable

--- a/thirdparty/perl-file-libmagic/Makefile
+++ b/thirdparty/perl-file-libmagic/Makefile
@@ -13,13 +13,6 @@ zname := zimbra-perl-$(pname_lc)
 zspec := $(pname_lc).spec
 
 libmagic = $(libmagic.$(BUILD_PLATFORM))
-libmagic.RHEL := file-devel
-libmagic.RHEL6_64 := $(libmagic.RHEL)
-libmagic.RHEL7_64 := $(libmagic.RHEL)
-libmagic.UBUNTU := libmagic-dev
-libmagic.UBUNTU12_64 := $(libmagic.UBUNTU)
-libmagic.UBUNTU14_64 := $(libmagic.UBUNTU)
-libmagic.UBUNTU16_64 := $(libmagic.UBUNTU)
 
 .PHONY: all clean build getsrc pkgadd pkgrm setup
 

--- a/thirdparty/perl-file-libmagic/RHEL.def
+++ b/thirdparty/perl-file-libmagic/RHEL.def
@@ -1,0 +1,3 @@
+libmagic.RHEL := file-devel
+libmagic.RHEL7_64 := $(libmagic.RHEL)
+libmagic.RHEL6_64 := $(libmagic.RHEL)

--- a/thirdparty/perl-file-libmagic/UBUNTU.def
+++ b/thirdparty/perl-file-libmagic/UBUNTU.def
@@ -1,0 +1,4 @@
+libmagic.UBUNTU := libmagic-dev
+libmagic.UBUNTU16_64 := $(libmagic.UBUNTU)
+libmagic.UBUNTU14_64 := $(libmagic.UBUNTU)
+libmagic.UBUNTU12_64 := $(libmagic.UBUNTU)

--- a/thirdparty/perl-socket/Makefile
+++ b/thirdparty/perl-socket/Makefile
@@ -13,12 +13,6 @@ zspec := $(pname_lc).spec
 
 .PHONY: all getsrc setup build clean pkgadd pkgrm
 
-PERL_REQ :=
-
-ifeq ($(BUILD_PLATFORM), RHEL6_64)
-	PERL_REQ := zimbra-perl-extutils-constant
-endif
-
 all: clean getsrc build pkgrm1
 
 # $(@D) == directory part of the target
@@ -26,8 +20,10 @@ getsrc: $(psrc_file)
 $(psrc_file):
 	$(MKDIR) $(@D) && $(CD) $(@D) && $(WGET) $(purl)
 
+extutils = $(extutils.$(BUILD_PLATFORM))
+
 pkgadd:
-	$(PKG_EXTRACT) zimbra-perl-base $(PERL_REQ)
+	$(PKG_EXTRACT) zimbra-perl-base $(extutils)
 
 pkgrm: pkgrm%
 pkgrm%:

--- a/thirdparty/perl-socket/RHEL6_64.def
+++ b/thirdparty/perl-socket/RHEL6_64.def
@@ -1,0 +1,1 @@
+extutils.RHEL6_64 := zimbra-perl-extutils-constant

--- a/thirdparty/perl-zmq-libzmq3/Makefile
+++ b/thirdparty/perl-zmq-libzmq3/Makefile
@@ -24,11 +24,6 @@ $(psrc_file):
 
 zpzc = zimbra-perl-zmq-constants
 zptest = $(zptest.$(BUILD_PLATFORM))
-zptest.UBUNTU := libtest-fatal-perl libtest-requires-perl libtest-sharedfork-perl libtry-tiny-perl
-zptest.UBUNTU16_64 := $(zptest.UBUNTU)
-zptest.UBUNTU14_64 := $(zptest.UBUNTU)
-zptest.UBUNTU12_64 := $(zptest.UBUNTU)
-zptest.RHEL7_64 := perl-Test-Fatal perl-Test-Requires
 
 pkgadd:
 	$(PKG_EXTRACT) zimbra-perl-base zimbra-zeromq-$(PKG_DEV) \

--- a/thirdparty/perl-zmq-libzmq3/RHEL.def
+++ b/thirdparty/perl-zmq-libzmq3/RHEL.def
@@ -1,0 +1,1 @@
+zptest.RHEL7_64 := perl-Test-Fatal perl-Test-Requires

--- a/thirdparty/perl-zmq-libzmq3/UBUNTU.def
+++ b/thirdparty/perl-zmq-libzmq3/UBUNTU.def
@@ -1,0 +1,4 @@
+zptest.UBUNTU := libtest-fatal-perl libtest-requires-perl libtest-sharedfork-perl libtry-tiny-perl
+zptest.UBUNTU16_64 := $(zptest.UBUNTU)
+zptest.UBUNTU14_64 := $(zptest.UBUNTU)
+zptest.UBUNTU12_64 := $(zptest.UBUNTU)

--- a/zimbra/os-requirements/Makefile
+++ b/zimbra/os-requirements/Makefile
@@ -7,11 +7,6 @@ zname := zimbra-$(pname_lc)
 zspec := $(pname_lc).spec
 
 osdeps = $(osdeps.$(BUILD_PLATFORM))
-osdeps.UBUNTU16_64 := libgmp10, libperl5.22
-osdeps.UBUNTU14_64 := libgmp10, libperl5.18
-osdeps.UBUNTU12_64 := libgmp3c2, libperl5.14
-osdeps.RHEL7_64 := nmap-ncat
-osdeps.RHEL6_64 := nc
 
 .PHONY: all clean build setup
 

--- a/zimbra/os-requirements/RHEL.def
+++ b/zimbra/os-requirements/RHEL.def
@@ -1,0 +1,2 @@
+osdeps.RHEL7_64 := nmap-ncat
+osdeps.RHEL6_64 := nc

--- a/zimbra/os-requirements/UBUNTU.def
+++ b/zimbra/os-requirements/UBUNTU.def
@@ -1,0 +1,3 @@
+osdeps.UBUNTU16_64 := libgmp10, libperl5.22
+osdeps.UBUNTU14_64 := libgmp10, libperl5.18
+osdeps.UBUNTU12_64 := libgmp3c2, libperl5.14


### PR DESCRIPTION
I'm working on porting Zimbra on a not-yet supported (or not-anymore since most platforms were dropped) platform/distribution.

This patch set allows me to work on this without touching def file sand Makefiles which require adaption. It does:

* Automatically detect the correct package-DIST.def file by looking at BUILD_PLATFORM.
* Includes additional def files in the package directories if they exist. Cf. 7deff8b for an explanation.
* Ports most of the packages which have platform specifica to this format.

I didn't touch `thirdparty/openjdk` and `thirdparty/perl-extutils-constant` since the overrides there aren't relevant for my case.

The affected packages still build fine on Ubuntu 14.04 (should be tested with a RHEL6_64 as well though).