### PR TITLE
bug 104788

### DIFF
--- a/thirdparty/openldap/patches/ITS8413.patch
+++ b/thirdparty/openldap/patches/ITS8413.patch
@@ -1,0 +1,83 @@
+From b61d02d942bfee96553cb4a8da0ddc112dded775 Mon Sep 17 00:00:00 2001
+From: Howard Chu <hyc@openldap.org>
+Date: Thu, 28 Apr 2016 03:04:16 +0100
+Subject: [PATCH] ITS#8413 don't use str2filter on precomputable filters
+
+and more importantly, avoid escaping requirements that str2filter has
+---
+ servers/slapd/syncrepl.c |   30 ++++++++++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/servers/slapd/syncrepl.c b/servers/slapd/syncrepl.c
+index 60f9b66..b692361 100644
+--- a/servers/slapd/syncrepl.c
++++ b/servers/slapd/syncrepl.c
+@@ -82,8 +82,9 @@ typedef struct syncinfo_s {
+ 	struct berval		si_base;
+ 	struct berval		si_logbase;
+ 	struct berval		si_filterstr;
+-	Filter			*si_filter;
+ 	struct berval		si_logfilterstr;
++	Filter			*si_filter;
++	Filter			*si_logfilter;
+ 	struct berval		si_contextdn;
+ 	int			si_scope;
+ 	int			si_attrsonly;
+@@ -2159,6 +2160,7 @@ syncrepl_op_modify( Operation *op, SlapReply *rs )
+ 		SlapReply rs1 = {0};
+ 		resolve_ctxt rx;
+ 		slap_callback cb = { NULL, syncrepl_resolve_cb, NULL, NULL };
++        Filter lf[3] = {0};
+ 
+ 		rx.rx_si = si;
+ 		rx.rx_mods = newlist;
+@@ -2186,7 +2188,19 @@ syncrepl_op_modify( Operation *op, SlapReply *rs )
+ 		op2.ors_filterstr.bv_len = sprintf(op2.ors_filterstr.bv_val,
+ 			"(&(entryCSN>=%s)(reqDN=%s)%s)",
+ 			bv.bv_val, op->o_req_ndn.bv_val, si->si_logfilterstr.bv_val );
+-		op2.ors_filter = str2filter_x( op, op2.ors_filterstr.bv_val );
++
++        lf[0].f_choice = LDAP_FILTER_AND;
++        lf[0].f_and = lf+1;
++        lf[1].f_choice = LDAP_FILTER_GE;
++        lf[1].f_av_desc = slap_schema.si_ad_entryCSN;
++        lf[1].f_av_value = bv;
++        lf[1].f_next = lf+2;
++        lf[2].f_choice = LDAP_FILTER_EQUALITY;
++        lf[2].f_av_desc = ad_reqDN;
++        lf[2].f_av_value = op->o_req_ndn;
++        lf[2].f_next = si->si_logfilter;
++
++		op2.ors_filter = lf;
+ 
+ 		op2.o_callback = &cb;
+ 		op2.o_bd = select_backend( &op2.o_req_ndn, 1 );
+@@ -4585,6 +4599,9 @@ syncinfo_free( syncinfo_t *sie, int free_all )
+ 		if ( sie->si_logfilterstr.bv_val ) {
+ 			ch_free( sie->si_logfilterstr.bv_val );
+ 		}
++		if ( sie->si_logfilter ) {
++			filter_free( sie->si_logfilter );
++		}
+ 		if ( sie->si_base.bv_val ) {
+ 			ch_free( sie->si_base.bv_val );
+ 		}
+@@ -5306,6 +5323,15 @@ parse_syncrepl_line(
+ 		return 1;
+ 	}
+ 
++	if ( si->si_got & GOT_LOGFILTER ) {
++		si->si_logfilter = str2filter( si->si_logfilterstr.bv_val );
++		if ( si->si_logfilter == NULL ) {
++			Debug( LDAP_DEBUG_ANY, "syncrepl %s " SEARCHBASESTR "=\"%s\": unable to parse logfilter=\"%s\"\n", 
++				si->si_ridtxt, c->be->be_suffix ? c->be->be_suffix[ 0 ].bv_val : "(null)", si->si_logfilterstr.bv_val );
++			return 1;
++		}
++	}
++
+ 	return 0;
+ }
+ 
+-- 
+1.7.10.4
+

--- a/thirdparty/openldap/zimbra-openldap/debian/changelog
+++ b/thirdparty/openldap/zimbra-openldap/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-openldap (VERSION-1zimbra8.7b4ZAPPEND) unstable; urgency=medium
+
+  * Add patch for ITS#8413
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 27 Apr 2016 22:26:24 +0000
+
 zimbra-openldap (VERSION-1zimbra8.7b3ZAPPEND) unstable; urgency=medium
 
   * Fix strip handling so debug packages are correctly generated.  Unique to OpenLDAP.

--- a/thirdparty/openldap/zimbra-openldap/debian/patches/series
+++ b/thirdparty/openldap/zimbra-openldap/debian/patches/series
@@ -5,3 +5,4 @@ ITS8054.patch
 threadpool.patch
 liblmdb-soname.patch
 ITS7506.patch
+ITS8413.patch

--- a/thirdparty/openldap/zimbra-openldap/rpm/SPECS/openldap.spec
+++ b/thirdparty/openldap/zimbra-openldap/rpm/SPECS/openldap.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's openldap build
 Name:               zimbra-openldap
 Version:            VERSION
-Release:            1zimbra8.7b2ZAPPEND
+Release:            1zimbra8.7b3ZAPPEND
 License:            BSD
 Source:             %{name}-%{version}.tgz
 Patch0:             ITS5037.patch
@@ -11,6 +11,7 @@ Patch3:             ITS8054.patch
 Patch4:             threadpool.patch
 Patch5:             liblmdb-soname.patch
 Patch6:             ITS7506.patch
+Patch7:             ITS8413.patch
 BuildRequires:      zimbra-openssl-devel
 BuildRequires:      zimbra-cyrus-sasl-devel
 BuildRequires:      zimbra-libltdl-devel
@@ -21,6 +22,8 @@ URL:                http://www.openldap.org
 The Zimbra openldap build
 
 %changelog
+* Wed Apr 27 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b3ZAPPEND
+- Add patch for ITS#8413
 * Thu Feb 11 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b2ZAPPEND
 - Add patch for ITS#7506
 
@@ -33,6 +36,7 @@ The Zimbra openldap build
 %patch4 -p1
 %patch5 -p1
 %patch6 -p1
+%patch7 -p1
 
 %build
 # Alternate Makeargs: DEFINES="-DCHECK_CSN -DSLAP_SCHEMA_EXPOSE -DMDB_DEBUG=3"

--- a/thirdparty/postfix-logwatch/zimbra-postfix-logwatch/rpm/SPECS/postfix-logwatch.spec
+++ b/thirdparty/postfix-logwatch/zimbra-postfix-logwatch/rpm/SPECS/postfix-logwatch.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's postfix-logwatch build
 Name:               zimbra-postfix-logwatch
-Version:            1.40.01
-Release:            1zimbra9.0b1
+Version:            VERSION
+Release:            ITERATIONZAPPEND
 License:            MIT
 Source:             %{name}-%{version}.tgz
 Requires:           zimbra-base


### PR DESCRIPTION
 Correctly handle entries in the accesslog that contain parenthesis by escaping the filter.  Upstream ITS8413