### PR TITLE
Bug 105058 - Fix RPM build of OpenJDK to set the correct perms on ct.sym

### DIFF
--- a/thirdparty/openjdk/zimbra-openjdk/rpm/SPECS/openjdk.spec
+++ b/thirdparty/openjdk/zimbra-openjdk/rpm/SPECS/openjdk.spec
@@ -47,6 +47,7 @@ ln -s openjdk* java
 rm -rf java/demo
 rm -rf java/sample
 rm -f java/jre/lib/security/cacerts
+chmod 644 java/lib/ct.sym
 cd java/jre/lib/security
 ln -s OZCE/java/cacerts cacerts
 cd ${RPM_BUILD_ROOT}OZCB


### PR DESCRIPTION
[root@c690 x86_64]# rpm -i zimbra-openjdk-1.8.0u92b14-1zimbra9.0b3.el6.x86_64.rpm
[root@c690 x86_64]# ls -l /opt/zimbra/common/lib/jvm/java/lib/ct.sym
-rw-r--r-- 1 root root 17726452 May 26 10:35 /opt/zimbra/common/lib/jvm/java/lib/ct.sym
