### PR TITLE
ZMS-59 - ngx_mail_throttle_module zimbraThrottleWhitelist support

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_handler.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_handler.c
@@ -353,7 +353,7 @@ ngx_mail_init_session(ngx_connection_t *c)
     if (login_ip_max == 0) {
         cb->on_allow(cb); //unlimited, direct allow session
     } else {
-        ngx_mail_throttle_ip(c->addr_text, cb);
+        ngx_mail_throttle_whitelist_ip(c->addr_text, cb);
     }
 }
 

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_handler.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_handler.c
@@ -353,7 +353,7 @@ ngx_mail_init_session(ngx_connection_t *c)
     if (login_ip_max == 0) {
         cb->on_allow(cb); //unlimited, direct allow session
     } else {
-        ngx_mail_throttle_ip(c->addr_text, s->protocol, cb);
+        ngx_mail_throttle_ip(c->addr_text, cb);
     }
 }
 

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.c
@@ -36,9 +36,19 @@ static char *ngx_mail_throttle_set_ttl_text
     (ngx_msec_t ttl, ngx_str_t * input, ngx_str_t * ttl_text);
 static char *ngx_mail_throttle_whitelist_ips
     (ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+void ngx_mail_throttle_whitelist_lookup_ip
+    (throttle_callback_t *callback);
+static void ngx_mail_throttle_whitelist_lookup_ip_success_handler
+    (mc_work_t *w);
+static void ngx_mail_throttle_whitelist_lookup_ip_failure_handler
+    (mc_work_t *w);
 static void ngx_mail_throttle_ip_success_handler
     (mc_work_t *w);
 static void ngx_mail_throttle_ip_failure_handler
+    (mc_work_t *w);
+static void ngx_mail_throttle_whitelist_ip_success_handler
+    (mc_work_t *w);
+static void ngx_mail_throttle_whitelist_ip_failure_handler
     (mc_work_t *w);
 static ngx_str_t ngx_mail_throttle_ip_ttl_txt
     (ngx_mail_throttle_srv_conf_t * tscf, ngx_uint_t protocol);
@@ -64,9 +74,10 @@ static void ngx_mail_throttle_user_success_handler
     (mc_work_t *w);
 static void ngx_mail_throttle_user_failure_handler
     (mc_work_t *w);
-
 static ngx_str_t ngx_mail_throttle_get_ip_throttle_key
    (ngx_pool_t *pool, ngx_log_t *log, ngx_str_t ip, ngx_uint_t protocol);
+static ngx_str_t ngx_mail_throttle_get_ip_whitelist_key
+   (ngx_pool_t *pool, ngx_log_t *log, ngx_str_t ip);
 static ngx_str_t ngx_mail_throttle_get_user_throttle_key
    (ngx_pool_t *pool, ngx_log_t *log, ngx_str_t user);
 static char * ngx_encode_protocol
@@ -400,30 +411,35 @@ ngx_mail_throttle_whitelist_ips (ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-/**
- * Return TRUE if ip should be whitelisted else FALSE
- */
-ngx_int_t 
-ngx_mail_throttle_ip_whitelisted (throttle_callback_t *callback, ngx_str_t *ip) {
+void
+ngx_mail_throttle_whitelist_lookup_ip (throttle_callback_t *callback) {
+    mc_work_t                        w;
     ngx_int_t                        i;
     ngx_cidr_t                       ip_cidr, *cidr;
     ngx_log_t                       *log;
-    ngx_int_t                        rc;
+    ngx_uint_t                       rc;
     ngx_mail_session_t              *session;
     ngx_mail_throttle_srv_conf_t    *tscf;
+    ngx_pool_t                      *pool;
+    ngx_str_t                        *ip, *cache_val, tmpval;
 
+    ip = callback->ip;
+    callback->is_whitelisted = 0;
     log = callback->log;
+    pool = callback->pool;
     session = callback->session;
 
     tscf = ngx_mail_get_module_srv_conf(session, ngx_mail_throttle_module);
     if (tscf->mail_throttle_whitelist_ips == NGX_CONF_UNSET_PTR) {
         ngx_log_error (NGX_LOG_DEBUG, log, 0, "no whitelisted ips, %V not whitelisted", ip);
-        return 0;
+        ngx_mail_throttle_ip(*ip, callback);
+        return;
     }
     rc = ngx_ptocidr(ip, &ip_cidr);
     if (rc == NGX_ERROR) {
         ngx_log_error (NGX_LOG_ERR, log, 0, "whitelisting ip %V do to error converting to cidr", ip);
-        return 0;
+        ngx_mail_throttle_ip(*ip, callback);
+        return;
     }
 #if (NGX_HAVE_INET6)
     if (ip_cidr.family == AF_INET6) {
@@ -442,7 +458,7 @@ ngx_mail_throttle_ip_whitelisted (throttle_callback_t *callback, ngx_str_t *ip) 
                      (cidr->u.in6.addr.__in6_u.__u6_addr32[3] & cidr->u.in6.mask.__in6_u.__u6_addr32[3]))
                    ) {
                     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "ngx_mail_throttle_ip_whitelisted: IPV6: %V is whitelisted", ip);
-                    return 1;
+                    callback->is_whitelisted = 1;
                 }
             }
         }
@@ -456,12 +472,70 @@ ngx_mail_throttle_ip_whitelisted (throttle_callback_t *callback, ngx_str_t *ip) 
                 ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "ngx_mail_throttle_ip_whitelisted: verify IPV4: %V", ip);
                 if ((ip_cidr.u.in.addr & cidr->u.in.mask) == (cidr->u.in.addr & cidr->u.in.mask)) {
                     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "ngx_mail_throttle_ip_whitelisted: IPV4: %V is whitelisted", ip);
-                    return 1;
+                    callback->is_whitelisted = 1;
                 }
             }
         }
     }
-    return 0;
+
+    tmpval.len = 1;
+    tmpval.data = callback->is_whitelisted ? "1" : "0";
+    cache_val = ngx_pstrcpy(pool, &tmpval);
+    if (cache_val == NULL) {
+        ngx_log_error (NGX_LOG_ERR, log, 0,
+            "Unable to cache fact that %V is_whitelisted=%d (alloc mem for cache_val)",
+            ip, callback->is_whitelisted);
+        if (callback->is_whitelisted) {
+            callback->on_allow(callback);
+        }
+        else {
+            ngx_mail_throttle_ip(*ip, callback);
+        }
+        return;
+    }
+
+    w.ctx = callback;
+    w.request_code = mcreq_add;
+    w.response_code = mcres_unknown;
+    w.on_success = ngx_mail_throttle_whitelist_lookup_ip_success_handler;
+    w.on_failure = ngx_mail_throttle_whitelist_lookup_ip_failure_handler;
+
+    ngx_memcache_post(&w, *callback->wl_key, *cache_val, NULL, log);
+}
+
+static void
+ngx_mail_throttle_whitelist_lookup_ip_success_handler (mc_work_t *w) {
+    ngx_log_t               *log;
+    throttle_callback_t     *callback;
+
+    callback = (throttle_callback_t *)w->ctx;
+    log = callback->log;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_MAIL, log, 0, "cached is_whitelisted=%d for IP %V", callback->is_whitelisted, callback->ip);
+
+    if (callback->is_whitelisted) {
+        callback->on_allow(callback);
+    }
+    else {
+        ngx_mail_throttle_ip(*callback->ip, callback);
+    }
+}
+
+static void
+ngx_mail_throttle_whitelist_lookup_ip_failure_handler (mc_work_t *w) {
+    ngx_log_t               *log;
+    throttle_callback_t     *callback;
+
+    callback = (throttle_callback_t *)w->ctx;
+    log = callback->log;
+
+    ngx_log_error (NGX_LOG_NOTICE, log, 0, "error trying to cache whitelist status for IP %V", callback->ip);
+    if (callback->is_whitelisted) {
+        callback->on_allow(callback);
+    }
+    else {
+        ngx_mail_throttle_ip(*callback->ip, callback);
+    }
 }
 
 /* check whether the client ip should be allowed to proceed, or whether
@@ -487,12 +561,6 @@ void ngx_mail_throttle_ip (ngx_str_t ip, throttle_callback_t *callback)
     w.response_code = mcres_unknown;
     w.on_success = ngx_mail_throttle_ip_success_handler;
     w.on_failure = ngx_mail_throttle_ip_failure_handler;
-
-    if (ngx_mail_throttle_ip_whitelisted(callback, &ip)) {
-        ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "allowing whitelisted ip %V login", &ip);
-        callback->on_allow(callback);
-        return;
-    }
 
     k = ngx_mail_throttle_get_ip_throttle_key(pool, log, ip, protocol);
 
@@ -642,6 +710,116 @@ static void ngx_mail_throttle_ip_failure_handler (mc_work_t *w)
              "memcache service is unavailable when try to "
              "increment ip counter", callback->ip);
         callback->on_allow(callback);
+    }
+}
+
+/* check cache to see whether the client ip is whitelisted.  if so,
+   invokes callback->on_allow.  if not, calls ngx_mail_throttle_ip.
+   If no IPs are configured for whitelisting, doesn't bother checking
+   cache and just calls ngx_mail_throttle_ip.
+ */
+void
+ngx_mail_throttle_whitelist_ip (ngx_str_t ip, throttle_callback_t *callback) {
+    ngx_log_t                       *log;
+    ngx_mail_session_t              *session;
+    ngx_mail_throttle_srv_conf_t    *tscf;
+    ngx_pool_t                      *pool;
+    mc_work_t                        w;
+    ngx_str_t                        k;
+    ngx_str_t                       *value, *eip, *key;
+
+    pool = callback->pool;
+    log = callback->log;
+    session = callback->session;
+    tscf = ngx_mail_get_module_srv_conf(session, ngx_mail_throttle_module);
+    if (tscf->mail_throttle_whitelist_ips == NGX_CONF_UNSET_PTR) {
+        ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "no configured whitelisted IPs, %V not whitelisted", &ip);
+        ngx_mail_throttle_ip(ip, callback);
+        return;
+    }
+
+    k = ngx_mail_throttle_get_ip_whitelist_key (pool, log, ip);
+    if (k.len == 0) {
+        ngx_log_error (NGX_LOG_ERR, log, 0,
+                "allowing ip %V login because of internal error"
+                "in ip throttle whitelist control (generate key for get)", &ip);
+        callback->on_allow(callback);
+        return;
+    }
+    key = ngx_pstrcpy (pool, &k);
+    if (key == NULL) {
+        ngx_log_error (NGX_LOG_ERR, log, 0,
+                "allowing ip %V login because of internal error"
+                "in ip throttle whitelist control (deep copy key for get)", &ip);
+        callback->on_allow(callback);
+    }
+    /* make a copy of the input IP address for callback reference */
+    eip = ngx_pstrcpy (pool, &ip);
+    if (eip == NULL) {
+        ngx_log_error (NGX_LOG_ERR, log, 0,
+                "allowing ip %V login because of internal error"
+                "in ip throttle whitelist control (deep copy ip for get)", &ip);
+        callback->on_allow(callback);
+        return;
+    }
+
+    callback->ip = eip;
+    callback->wl_key = key;
+
+    w.ctx = callback;
+    w.request_code = mcreq_get;
+    w.response_code = mcres_unknown;
+    w.on_success = ngx_mail_throttle_whitelist_ip_success_handler;
+    w.on_failure = ngx_mail_throttle_whitelist_ip_failure_handler;
+
+    ngx_memcache_post(&w, *key, NGX_EMPTY_STR,/* pool */ NULL, log);
+}
+
+static void
+ngx_mail_throttle_whitelist_ip_success_handler (mc_work_t *w) {
+    ngx_log_t           *log;
+    ngx_pool_t          *pool;
+    throttle_callback_t *callback;
+
+    callback = (throttle_callback_t *)w->ctx;
+    log = callback->log;
+    pool = callback->pool;
+
+    if (w->payload.len > 0) {
+        if (w->payload.data[0] == '1') {
+            ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "ip %V whitelisted (from cache)", callback->ip);
+            callback->on_allow(callback);
+            return;
+        }
+        else if (w->payload.data[0] == '0') {
+            ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "ip %V is not whitelisted (from cache)", callback->ip);
+            ngx_mail_throttle_ip(*callback->ip, callback);
+            return;
+        }
+    }
+    else {
+        ngx_mail_throttle_whitelist_lookup_ip(callback);
+    }
+}
+
+static void
+ngx_mail_throttle_whitelist_ip_failure_handler (mc_work_t *w) {
+
+    ngx_log_t           *log;
+    throttle_callback_t *callback;
+
+    callback = (throttle_callback_t *)w->ctx;
+    log = callback->log;
+
+    if (w->response_code == mcres_failure_normal) {
+        // NOT FOUND
+        ngx_log_debug1(NGX_LOG_DEBUG_MAIL, log, 0, "whitelist status for IP %V not found in cache", callback->ip);
+        ngx_mail_throttle_whitelist_lookup_ip(callback);
+    }
+    else {
+        ngx_log_error (NGX_LOG_ERR, log, 0,
+            "cache failure trying to see if %V should be whitelisted", callback->ip);
+        ngx_mail_throttle_ip(*callback->ip, callback);
     }
 }
 
@@ -1306,6 +1484,38 @@ ngx_mail_throttle_get_ip_throttle_key (
     p = ngx_cpymem(p, "proto=", sizeof("proto=") - 1);
     p = ngx_cpymem(p, ngx_encode_protocol(protocol, 's'), 1);
     p = ngx_cpymem(p, ",ip=", sizeof(",ip=") - 1);
+    p = ngx_cpymem(p, ip.data, ip.len);
+
+    k.len = p - k.data;
+
+    return k;
+}
+
+static ngx_str_t
+ngx_mail_throttle_get_ip_whitelist_key (
+    ngx_pool_t      *pool,
+    ngx_log_t       *log,
+    ngx_str_t        ip
+)
+{
+    ngx_str_t   k;
+    size_t      l;
+    u_char     *p;
+
+    l = sizeof("whitelist:") - 1 +
+        sizeof("ip=") - 1 +
+        ip.len;
+
+    k.data = ngx_palloc(pool, l);
+    if (k.data == NULL)
+    {
+        k.len = 0;
+        return k;
+    }
+
+    p = k.data;
+    p = ngx_cpymem(p, "whitelist:", sizeof("whitelist:") - 1);
+    p = ngx_cpymem(p, "ip=", sizeof("ip=") - 1);
     p = ngx_cpymem(p, ip.data, ip.len);
 
     k.len = p - k.data;

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
@@ -57,16 +57,19 @@ struct throttle_callback_s {
     throttle_handler_pt     on_deny;  /* handler for deny access */
 
     /* the following fields are used internally by throttle control */
-    ngx_str_t              *user; /* user name used by user throttle control */
-    ngx_str_t              *ip;   /* ip address used by ip throttle control */
-    ngx_str_t              *value;/* the value for re-post memcache request */
-    ngx_str_t              *key;  /* the key for re-post memcache request */
-    ngx_str_t              *ttl;  /* the ttl value for re-post memcache request */
+    ngx_str_t              *user;           /* user name used by user throttle control */
+    ngx_str_t              *ip;             /* ip address used by ip throttle control */
+    ngx_str_t              *value;          /* the value for re-post memcache request */
+    ngx_str_t              *key;            /* the key for re-post memcache request */
+    ngx_str_t              *ttl;            /* the ttl value for re-post memcache request */
+    ngx_str_t              *wl_key;         /* key for whitelist IP memcache add */
+    ngx_uint_t              is_whitelisted; /* used by whitelist IP memcache callback */
 };
 typedef struct throttle_callback_s throttle_callback_t;
 
 ngx_flag_t ngx_mail_throttle_init (ngx_mail_core_srv_conf_t *cscf);
 void ngx_mail_throttle_ip (ngx_str_t ip, throttle_callback_t *callback);
+void ngx_mail_throttle_whitelist_ip (ngx_str_t ip, throttle_callback_t *callback);
 void ngx_mail_throttle_user (ngx_str_t user, throttle_callback_t *callback);
 ngx_uint_t ngx_mail_throttle_ip_max_for_protocol (ngx_mail_throttle_srv_conf_t *tscf, ngx_uint_t protocol);
 

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
@@ -66,7 +66,7 @@ struct throttle_callback_s {
 typedef struct throttle_callback_s throttle_callback_t;
 
 ngx_flag_t ngx_mail_throttle_init (ngx_mail_core_srv_conf_t *cscf);
-void ngx_mail_throttle_ip (ngx_str_t ip, ngx_uint_t protocol, throttle_callback_t *callback);
+void ngx_mail_throttle_ip (ngx_str_t ip, throttle_callback_t *callback);
 void ngx_mail_throttle_user (ngx_str_t user, throttle_callback_t *callback);
 ngx_uint_t ngx_mail_throttle_ip_max_for_protocol (ngx_mail_throttle_srv_conf_t *tscf, ngx_uint_t protocol);
 

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
@@ -22,22 +22,23 @@
 #include <ngx_memcache.h>
 
 struct ngx_mail_throttle_srv_conf_s {
-    ngx_uint_t  mail_login_ip_max;
-    ngx_msec_t  mail_login_ip_ttl;
-    ngx_str_t   mail_login_ip_ttl_text;
-    ngx_str_t   mail_login_ip_imap_ttl_text;
-    ngx_str_t   mail_login_ip_pop3_ttl_text;
-    ngx_str_t   mail_login_ip_rejectmsg;
-    ngx_uint_t  mail_login_user_max;
-    ngx_msec_t  mail_login_user_ttl;
-    ngx_str_t   mail_login_user_ttl_text;
-    ngx_str_t   mail_login_user_rejectmsg;
-    ngx_uint_t  mail_login_ip_imap_max;
-    ngx_msec_t  mail_login_ip_imap_ttl;
-    ngx_uint_t  mail_login_ip_pop3_max;
-    ngx_msec_t  mail_login_ip_pop3_ttl;
+    ngx_uint_t   mail_login_ip_max;
+    ngx_msec_t   mail_login_ip_ttl;
+    ngx_str_t    mail_login_ip_ttl_text;
+    ngx_str_t    mail_login_ip_imap_ttl_text;
+    ngx_str_t    mail_login_ip_pop3_ttl_text;
+    ngx_str_t    mail_login_ip_rejectmsg;
+    ngx_uint_t   mail_login_user_max;
+    ngx_msec_t   mail_login_user_ttl;
+    ngx_str_t    mail_login_user_ttl_text;
+    ngx_str_t    mail_login_user_rejectmsg;
+    ngx_uint_t   mail_login_ip_imap_max;
+    ngx_msec_t   mail_login_ip_imap_ttl;
+    ngx_uint_t   mail_login_ip_pop3_max;
+    ngx_msec_t   mail_login_ip_pop3_ttl;
     ngx_array_t *mail_throttle_whitelist_ips;     /* array of ngx_cidr_t */
-
+    time_t       mail_whitelist_ip_ttl;
+    ngx_str_t    mail_whitelist_ip_ttl_text;
 };
 typedef struct ngx_mail_throttle_srv_conf_s ngx_mail_throttle_srv_conf_t;
 

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_throttle_module.h
@@ -36,6 +36,8 @@ struct ngx_mail_throttle_srv_conf_s {
     ngx_msec_t  mail_login_ip_imap_ttl;
     ngx_uint_t  mail_login_ip_pop3_max;
     ngx_msec_t  mail_login_ip_pop3_ttl;
+    ngx_array_t *mail_throttle_whitelist_ips;     /* array of ngx_cidr_t */
+
 };
 typedef struct ngx_mail_throttle_srv_conf_s ngx_mail_throttle_srv_conf_t;
 


### PR DESCRIPTION
## Summary

This adds support for *whitelisting* IPV4 or IPV6 addresses so that they will not be subject to the IMAP or POP3 throttling configuration.  The new nginx configuration directive is `mail_whitelist_ip`.  This directive may be repeated as many times as necessary.  Currently this is done in the `nginx.conf.mail` configuration file.

Ranges of IP addresses may be whitelisted via a single directive by using the appropriate [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) notation.  Note that when IPV6 is enabled for the cluster, you should use IPV6-formatted entries in the configuration file.  IPV6 mode is enabled when `zimbraIPMode` is set to `ipv6` or `both`.

## Examples

Whitelist everything on the `10.0.2.x` subnet using IPV4 notation:

    mail_whitelist_ip 10.0.2.0/24;

Whitelist everything on the `10.0.2.x` subnet using IPV6 notation:

    mail_whitelist_ip ::ffff:10.0.2.0/120;

## Updates

- Have addressed the concerns from the early reviews
- Have added IP whitelist lookup caching
- Added IP whitelist ttl support

