### PR TITLE
Bug 106498 - Configurable option for upstream_fair_shm_size in nginx

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream_fair.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream_fair.c
@@ -70,6 +70,8 @@ static ngx_shm_zone_t * ngx_http_upstream_fair_shm_zone;
 static ngx_rbtree_t * ngx_http_upstream_fair_rbtree;
 static ngx_uint_t ngx_http_upstream_fair_generation;
 
+ngx_uint_t *shm_size = &ngx_http_upstream_fair_shm_size;
+
 static int
 ngx_http_upstream_fair_compare_rbtree_node(const ngx_rbtree_node_t *v_left,
     const ngx_rbtree_node_t *v_right)
@@ -480,8 +482,11 @@ ngx_http_upstream_init_fair(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
     shm_name->data = (unsigned char *) "upstream_fair";
 
     if (ngx_http_upstream_fair_shm_size == 0) {
+        ngx_log_error(NGX_LOG_WARN, cf->log, 0, "The upstream_fair_shm_size is 0. The upstream_fair_shm_size value must be at least %udKiB", (8 * ngx_pagesize) >> 10);
         ngx_http_upstream_fair_shm_size = 8 * ngx_pagesize;
     }
+
+    ngx_log_error(NGX_LOG_DEBUG_ZIMBRA, cf->log, 0, "The upstream_fair_shm_size value is %udKiB", ngx_http_upstream_fair_shm_size >> 10);
 
     ngx_http_upstream_fair_shm_zone = ngx_shared_memory_add(
         cf, shm_name, ngx_http_upstream_fair_shm_size, &ngx_http_upstream_fair_module);

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream_fair.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream_fair.h
@@ -97,6 +97,8 @@ typedef struct {
     ngx_flag_t                          exact_version_check;
 } ngx_http_upstream_fair_peer_data_t;
 
+extern ngx_uint_t *shm_size;
+
 ngx_int_t ngx_http_upstream_init_fair(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *us);
 ngx_int_t ngx_http_upstream_init_fair_peer(ngx_http_request_t *r,


### PR DESCRIPTION
The upstream_fair module was integrated into zimbra as part of bug #95921. But the upstream_fair_shm_size was not made configurable, and a hardcoded (8 * ngx_pagesize) value was used.
Since we are using the upstream_fair from the zm_auth module, I have added the upstream_fair_shm_size directive into the zm_auth module. Zimbra code to create an ldap attribute to configure the value of upstream_fair_shm_size using zmproxyconfgen will be handled in separate bug. Till that time, users will have to manually change nginx.conf.web.template and add upstream_fair_shm_size value.
If upstream_fair_shm_size is not specified, a default 32k will be used.