### PR TITLE
Bug 106498 Change log level from warning to debug

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream_fair.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream_fair.c
@@ -482,7 +482,7 @@ ngx_http_upstream_init_fair(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
     shm_name->data = (unsigned char *) "upstream_fair";
 
     if (ngx_http_upstream_fair_shm_size == 0) {
-        ngx_log_error(NGX_LOG_WARN, cf->log, 0, "The upstream_fair_shm_size is 0. The upstream_fair_shm_size value must be at least %udKiB", (8 * ngx_pagesize) >> 10);
+        ngx_log_error(NGX_LOG_DEBUG_ZIMBRA, cf->log, 0, "The upstream_fair_shm_size is 0. The upstream_fair_shm_size value must be at least %udKiB", (8 * ngx_pagesize) >> 10);
         ngx_http_upstream_fair_shm_size = 8 * ngx_pagesize;
     }
 


### PR DESCRIPTION
Before deploying change:

    zimbra@ubuntu-test-1:~$ zmproxyctl restart
    Stopping proxy...done.
    Starting proxy...nginx: [warn] The upstream_fair_shm_size is 0. The upstream_fair_shm_size value must be at least 32KiB

After deploying change:

    zimbra@ubuntu-test-1:~$ zmproxyctl restart
    Stopping proxy...done.
    Starting proxy...done.

