### PR TITLE
BUG:107201, ZCS-412 - Upgraded MARIADB to latest (10.1.25) to fix CVE-2016-6664

### DIFF
--- a/zimbra/core-components/Makefile
+++ b/zimbra/core-components/Makefile
@@ -24,7 +24,7 @@ build_rpm:
 
 build_deb:
 	$(CD) $(PLATFORM_DIR)/$(zname) && \
-	$(replace-pkginfo) debian/changelog && \
+	$(replace-pkginfo) debian/changelog debian/control && \
 	$(PKG_BUILD)
 
 clean:

--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,4 +1,9 @@
-zimbra-core-components (1.0.0-ITERATIONZAPPEND) unstable; urgency=low
+zimbra-core-components (1.0.1-1zimbra8.7b1ZAPPEND) unstable; urgency=low
+
+  * Updated zimbra-mariadb package.
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 24 Jul 2017 00:00:00 +0000
+zimbra-core-components (1.0.0-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Initial Release.
 

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -10,7 +10,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-base, zimbra-os-requirements, zimbra-perl, zimbra-pflogsumm,
  zimbra-openssl, zimbra-curl, zimbra-cyrus-sasl, zimbra-rsync,
- zimbra-mariadb-lib, zimbra-openldap-client, zimbra-prepflog,
+ zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b1ZAPPEND), zimbra-openldap-client, zimbra-prepflog,
  zimbra-tcmalloc-lib, zimbra-perl-innotop, zimbra-openjdk,
  zimbra-openjdk-cacerts, zimbra-osl, zimbra-amavis-logwatch,
  zimbra-postfix-logwatch, zimbra-rrdtool

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,11 +1,11 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            1.0.0
-Release:            ITERATIONZAPPEND
+Version:            1.0.1
+Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-base, zimbra-os-requirements, zimbra-perl, zimbra-pflogsumm
 Requires:           zimbra-openssl,zimbra-curl, zimbra-cyrus-sasl, zimbra-rsync
-Requires:           zimbra-mariadb-libs, zimbra-openldap-client, zimbra-osl
+Requires:           zimbra-mariadb-libs >= 10.1.25-1zimbra8.7b1ZAPPEND, zimbra-openldap-client, zimbra-osl
 Requires:           zimbra-prepflog, zimbra-tcmalloc-libs, zimbra-perl-innotop
 Requires:           zimbra-openjdk, zimbra-openjdk-cacerts, zimbra-amavis-logwatch
 Requires:           zimbra-postfix-logwatch, zimbra-rrdtool
@@ -14,6 +14,12 @@ Group:              Development/Languages
 AutoReqProv:        no
 
 %define debug_package %{nil}
+
+%changelog
+* Mon Jul 24 2017  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.1
+- Updated zimbra-mariadb package
+* Wed Sep 09 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.0
+- Initial Release
 
 %description
 Zimbra core components pulls in all the packages used by

--- a/zimbra/mta-components/zimbra-mta-components/debian/changelog
+++ b/zimbra/mta-components/zimbra-mta-components/debian/changelog
@@ -1,21 +1,26 @@
-zimbra-mta-components (1.0.3-ITERATIONZAPPEND) unstable; urgency=low
+zimbra-mta-components (1.0.4-1zimbra8.7b1ZAPPEND) unstable; urgency=low
+
+  * Updated zimbra-mariadb package.
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 24 Jul 2017 00:00:00 +0000
+zimbra-mta-components (1.0.3-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Updated zimbra-perl-mail-spamassassin package
 
  -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Tue, 18 Jul 2017 00:00:00 +0000
-zimbra-mta-components (1.0.2-ITERATIONZAPPEND) unstable; urgency=low
+zimbra-mta-components (1.0.2-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Add ClamAV initial databases
 
  -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 9 Mar 2016 00:00:00 +0000
 
-zimbra-mta-components (1.0.1-ITERATIONZAPPEND) unstable; urgency=low
+zimbra-mta-components (1.0.1-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Add Spamassassin default ruleset
 
  -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 14 Dec 2015 00:00:00 +0000
 
-zimbra-mta-components (1.0.0-ITERATIONZAPPEND) unstable; urgency=low
+zimbra-mta-components (1.0.0-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Initial Release.
 

--- a/zimbra/mta-components/zimbra-mta-components/debian/control
+++ b/zimbra/mta-components/zimbra-mta-components/debian/control
@@ -9,7 +9,7 @@ Package: zimbra-mta-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  sqlite3, zimbra-mta-base, zimbra-altermime, zimbra-amavisd,
- zimbra-clamav, zimbra-clamav-db, zimbra-cluebringer, zimbra-mariadb,
+ zimbra-clamav, zimbra-clamav-db, zimbra-cluebringer, zimbra-mariadb (>= 10.1.25-1zimbra8.7b1ZAPPEND),
  zimbra-opendkim, zimbra-perl-mail-spamassassin (>= 3.4.1-1zimbra8.7b2ZAPPEND), zimbra-postfix,
  zimbra-spamassassin-rules
 Description: Zimbra components for MTA package

--- a/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
+++ b/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
@@ -1,10 +1,10 @@
 Summary:            Zimbra components for MTA package
 Name:               zimbra-mta-components
-Version:            1.0.3
-Release:            ITERATIONZAPPEND
+Version:            1.0.4
+Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
 Requires:           sqlite, zimbra-mta-base, zimbra-altermime, zimbra-amavisd
-Requires:           zimbra-clamav, zimbra-clamav-db, zimbra-cluebringer, zimbra-mariadb
+Requires:           zimbra-clamav, zimbra-clamav-db, zimbra-cluebringer, zimbra-mariadb >= 10.1.25-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-opendkim, zimbra-perl-mail-spamassassin >= 3.4.1-1zimbra8.7b2ZAPPEND, zimbra-postfix
 Requires:           zimbra-spamassassin-rules
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
@@ -18,6 +18,8 @@ Zimbra mta components pulls in all the packages used by
 zimbra-mta
 
 %changelog
+* Mon Jul 24 2017  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4
+- Updated zimbra-mariadb package
 * Tue Jul 18 2017  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3
 - Updated zimbra-perl-mail-spamassassin package
 * Wed Mar 09 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.2

--- a/zimbra/store-components/Makefile
+++ b/zimbra/store-components/Makefile
@@ -24,7 +24,7 @@ build_rpm:
 
 build_deb:
 	$(CD) $(PLATFORM_DIR)/$(zname) && \
-	$(replace-pkginfo) debian/changelog && \
+	$(replace-pkginfo) debian/changelog debian/control && \
 	$(PKG_BUILD)
 
 clean:

--- a/zimbra/store-components/zimbra-store-components/debian/changelog
+++ b/zimbra/store-components/zimbra-store-components/debian/changelog
@@ -1,4 +1,9 @@
-zimbra-store-components (1.0.0-ITERATIONZAPPEND) unstable; urgency=low
+zimbra-store-components (1.0.1-1zimbra8.7b1ZAPPEND) unstable; urgency=low
+
+  * Updated zimbra-mariadb package.
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Tue, 18 Jul 2017 00:00:00 +0000
+zimbra-store-components (1.0.0-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Initial Release.
 

--- a/zimbra/store-components/zimbra-store-components/debian/control
+++ b/zimbra/store-components/zimbra-store-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-store-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-store-base, zimbra-mariadb
+ zimbra-store-base, zimbra-mariadb (>= 10.1.25-1zimbra8.7b1ZAPPEND)
 Description: Zimbra components for store package
  Zimbra store components pulls in all the packages used by
  zimbra-store

--- a/zimbra/store-components/zimbra-store-components/rpm/SPECS/store-components.spec
+++ b/zimbra/store-components/zimbra-store-components/rpm/SPECS/store-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for store package
 Name:               zimbra-store-components
-Version:            1.0.0
-Release:            ITERATIONZAPPEND
+Version:            1.0.1
+Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-store-base, zimbra-mariadb
+Requires:           zimbra-store-base, zimbra-mariadb >= 10.1.25-1zimbra8.7b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -13,5 +13,11 @@ AutoReqProv:        no
 %description
 Zimbra store components pulls in all the packages used by
 zimbra-store
+
+%changelog
+* Mon Jul 24 2017  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.1
+- Updated zimbra-mariadb package
+* Wed Sep 09 2015  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.0
+- Initial Release
 
 %files


### PR DESCRIPTION
Upgraded zimbra-core-components, zimbra-store-components, zimbra-mta-components to allow upgrade of MariaDB to 10.1.25.  This continues the changes done for zimbra-mariadb upgrade via commit 318df78d1.