### PR TITLE
Adding RFC822Name to certauth

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_zm_sso_module.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_zm_sso_module.h
@@ -21,6 +21,13 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/engine.h>
+#include <openssl/evp.h>
+#include <openssl/ocsp.h>
+
 typedef struct {
     ngx_uint_t  type;                     /* the authentication type */
     ngx_url_t  *redirect_url;             /* if only port is provided, just redirect to $host:port */
@@ -41,7 +48,8 @@ typedef struct {
 /* SSO type */
 #define NGX_ZM_SSO_CERTAUTH       1           /* client cert authentication */
 #define NGX_ZM_SSO_CERTAUTH_ADMIN 2           /* client cert authentication for admin console */
-
+#define NGX_ZM_SSO_CERTAUTH_RFC822NAME       3           /* client cert authentication using RFC822Name */
+#define NGX_ZM_SSO_CERTAUTH_ADMIN_RFC822NAME 4           /* client cert authentication for admin console using RFC822Name */
 
 extern ngx_module_t ngx_http_zm_sso_module;
 


### PR DESCRIPTION
Add the possibility to use RFC822Name to do client certificate authentication, now there is two more parameters, and you can configure like that on nginx:

    location = /certauth {
        zm_sso certauth_rfc822name;
        zm_sso_redirect_url 443;
    }

    location = /certauth/admin {
        zm_sso certauth_admin_rfc822name;
        zm_sso_redirect_url 9071;
    }


