### PR TITLE
ssl_client_escaped_cert nginx backport

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/event/ngx_event_openssl.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/event/ngx_event_openssl.c
@@ -2941,6 +2941,36 @@ ngx_ssl_get_certificate(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
 
 ngx_int_t
+ngx_ssl_get_escaped_certificate(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s)
+{
+    ngx_str_t  cert;
+    uintptr_t  n;
+
+    if (ngx_ssl_get_raw_certificate(c, pool, &cert) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (cert.len == 0) {
+        s->len = 0;
+        return NGX_OK;
+    }
+
+    n = ngx_escape_uri(NULL, cert.data, cert.len, NGX_ESCAPE_URI_COMPONENT);
+
+    s->len = cert.len + n * 2;
+    s->data = ngx_pnalloc(pool, s->len);
+    if (s->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_escape_uri(s->data, cert.data, cert.len, NGX_ESCAPE_URI_COMPONENT);
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
 ngx_ssl_get_subject_dn(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
     char       *p;

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/event/ngx_event_openssl.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/event/ngx_event_openssl.h
@@ -167,6 +167,8 @@ ngx_int_t ngx_ssl_get_raw_certificate(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_certificate(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_escaped_certificate(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 ngx_int_t ngx_ssl_get_subject_dn(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_issuer_dn(ngx_connection_t *c, ngx_pool_t *pool,

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_ssl_module.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_ssl_module.c
@@ -283,6 +283,10 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
       (uintptr_t) ngx_ssl_get_raw_certificate,
       NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_client_escaped_cert"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_escaped_certificate,
+      NGX_HTTP_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_client_s_dn"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_subject_dn, NGX_HTTP_VAR_CHANGEABLE, 0 },
 


### PR DESCRIPTION
Backport of nginx [Ticket #857](https://trac.nginx.org/nginx/ticket/857?cversion=0&cnum_hist=4#comment:7), now it is possible to pass client certificate through proxy header without breaking jetty http parser (RFC7230). The new variable that can be used is $ssl_client_escaped_cert (the data will be a single line URL encoded pem) and it can be used like that:

    proxy_set_header X-Client-Certificate $ssl_client_escaped_cert;