### PR TITLE
ZBUG-173: nginx lookup does not fail over to next server when peer store server is down or can't connect

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -760,9 +760,15 @@ ngx_zm_lookup_ssl_init_connection(ngx_ssl_t* ssl, ngx_connection_t *c)
         else if (rc == NGX_ERROR)
         {
             ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
-                    "zm lookup: ngx_zm_lookup_ssl_init_connection ssl event failed");
+                    "zm lookup: ngx_zm_lookup_ssl_init_connection ssl event failed with NGX_ERROR");
             ngx_zm_lookup_ssl_handshake(c);
             return ZM_LOOKUP_SSL_EVENT_FAILED;
+        }
+        else
+        {
+            ngx_log_debug1 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
+                    "zm lookup: ngx_zm_lookup_ssl_init_connection ssl event failed with error %i", rc);
+            return ZM_LOOKUP_SSL_EVENT_FAILED; 
         }
     }while (rc == NGX_AGAIN);
 

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -749,21 +749,22 @@ ngx_zm_lookup_ssl_init_connection(ngx_ssl_t* ssl, ngx_connection_t *c)
 
     c->log->action = "SSL handshaking to lookup handler";
 
-    rc = ngx_ssl_handshake(c);
-    if(rc == NGX_ERROR)
-    {
-        ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
-                         "zm lookup: ngx_zm_lookup_ssl_init_connection ssl event failed");
-        ngx_zm_lookup_ssl_handshake(c);
-        return ZM_LOOKUP_SSL_EVENT_FAILED;
-    }
-
-    if (rc == NGX_AGAIN) {
-        c->ssl->handler = ngx_zm_lookup_ssl_handshake;
-        ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
-                         "zm lookup: ngx_zm_lookup_ssl_init_connection ngx_ssl_handshake returned NGX_AGAIN");
-        return ZM_LOOKUP_SSL_EVENT_SUCCESS;
-    }
+    do {
+        rc = ngx_ssl_handshake(c);
+        if(rc == NGX_AGAIN)
+        {
+            ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
+                    "zm lookup: ngx_zm_lookup_ssl_init_connection ngx_ssl_handshake returned NGX_AGAIN");
+            sleep(1);
+        }
+        else if (rc == NGX_ERROR)
+        {
+            ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
+                    "zm lookup: ngx_zm_lookup_ssl_init_connection ssl event failed");
+            ngx_zm_lookup_ssl_handshake(c);
+            return ZM_LOOKUP_SSL_EVENT_FAILED;
+        }
+    }while (rc == NGX_AGAIN);
 
     ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
             "zm lookup: ngx_zm_lookup_ssl_init_connection before call to ngx_zm_lookup_ssl_handshake");

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -764,12 +764,6 @@ ngx_zm_lookup_ssl_init_connection(ngx_ssl_t* ssl, ngx_connection_t *c)
             ngx_zm_lookup_ssl_handshake(c);
             return ZM_LOOKUP_SSL_EVENT_FAILED;
         }
-        else
-        {
-            ngx_log_debug1 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
-                    "zm lookup: ngx_zm_lookup_ssl_init_connection ssl event failed with error %i", rc);
-            return ZM_LOOKUP_SSL_EVENT_FAILED; 
-        }
     }while (rc == NGX_AGAIN);
 
     ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -755,7 +755,7 @@ ngx_zm_lookup_ssl_init_connection(ngx_ssl_t* ssl, ngx_connection_t *c)
         {
             ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
                     "zm lookup: ngx_zm_lookup_ssl_init_connection ngx_ssl_handshake returned NGX_AGAIN");
-            sleep(1);
+            ngx_msleep(5);
         }
         else if (rc == NGX_ERROR)
         {
@@ -830,7 +830,7 @@ ngx_zm_lookup_connect (ngx_zm_lookup_ctx_t * ctx)
         if(ngx_zm_lookup_ssl_init_connection(zlcf->ssl, ctx->peer.connection) == ZM_LOOKUP_SSL_EVENT_FAILED)
         {
             ngx_log_error(NGX_LOG_WARN, ctx->log, 0, "zm lookup: ngx_zm_lookup_connect "
-                    "connect lookup handle error, fail over to the next one");
+                    "connect lookup handle error for host:%V, uri:%V, fail over to the next one",ctx->peer.name, &handler->uri);
             ngx_zm_lookup_connect(ctx);
         }
         return;

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.h
@@ -145,6 +145,8 @@ typedef struct ngx_zm_lookup_ctx_s ngx_zm_lookup_ctx_t;
 #define ZM_LOOKUP_INVALID_RESPONSE        9
 #define ZM_LOOKUP_CLIENT_CONNECTION_CLOSE 10
 #define ZM_LOOKUP_OTHER_ERROR             50
+#define ZM_LOOKUP_SSL_EVENT_SUCCESS       0
+#define ZM_LOOKUP_SSL_EVENT_FAILED        1
 
 /* the protocols nginx lookup can serve for */
 #define ZM_PROTO_UNKNOWN 0

--- a/thirdparty/nginx/zimbra-nginx/debian/changelog
+++ b/thirdparty/nginx/zimbra-nginx/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-nginx (VERSION-1zimbra8.7b8ZAPPEND) unstable; urgency=medium
+
+  * Patch for nginx Bug 107566
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 24 Aug 2018 13:48:22 +0530
+
 zimbra-nginx (VERSION-1zimbra8.7b7ZAPPEND) unstable; urgency=medium
 
   * Patch for nginx Bug 107438 (and 106918, 106876)

--- a/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
+++ b/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's nginx build
 Name:               zimbra-nginx
 Version:            VERSION
-Release:            1zimbra8.7b7ZAPPEND
+Release:            1zimbra8.7b8ZAPPEND
 License:            MIT
 Source:             %{name}-%{version}.tar.gz
 BuildRequires:      pcre-devel, zlib-devel
@@ -17,6 +17,8 @@ URL:                http://nginx.org
 The Zimbra nginx build
 
 %changelog
+* Fri Aug 24 2018  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b8ZAPPEND
+- Patch for nginx Bug 107566
 * Wed May 10 2017  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b7ZAPPEND
 - Patch for nginx Bug 107438 (and 106918, 106876)
 - Patch for nginx Bug 106948.


### PR DESCRIPTION
**Problem:** lookup does not happen to the next server in case of https (ssl)

**Approach and Fix:**
Introduced the implementation that iterates to the next handler when one is down.

**Use cases simulating the scenario:** All Passed
1.All invalid handlers.
	Configuration:
		zm_lookup_handlers  https://10.15.233.175:7072/service/extension/nginx-lookup https://10.15.234.175:7072/service/extension/nginx-lookup https://10.15.235.175:7072/service/extension/nginx-lookup;
	Expectation:
		Fall back to IPHASH
	Log output:
		zmauth: an error occurs during zm lookup: no valid lookup handlers, fall back to IPHASH to get the upstream route while SSL handshaking
		
2.Two invalid handlers at beginning and one valid handler at last.
	Configuration:
		zm_lookup_handlers  https://10.15.233.175:7072/service/extension/nginx-lookup https://10.15.234.175:7072/service/extension/nginx-lookup https://10.15.33.175:7072/service/extension/nginx-lookup;
	Expectation:
		No Fall back to IPHASH
		Valid handler for 10.15.33.175 should be used
	Log output:
		zm lookup: ngx_zm_lookup_ssl_init_connection ngx_ssl_handshake returned NGX_AGAIN
		
3.Two invalid handlers at beginning and end, and one valid handler in between of invalid ones.
	Configuration:
		zm_lookup_handlers  https://10.15.233.175:7072/service/extension/nginx-lookup https://10.15.33.175:7072/service/extension/nginx-lookup https://10.15.234.175:7072/service/extension/nginx-lookup;
	Expectation:
		No Fall back to IPHASH
		Valid handler for 10.15.33.175 should be used
	Log output:
		zm lookup: ngx_zm_lookup_ssl_init_connection ngx_ssl_handshake returned NGX_AGAIN

Memory profiling done.
Testing by QA done.
Memory profiling done on latest code.