### PR TITLE
ZCS-5790:login gets 502 when one of MBS servers is down

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/ngx_http_upstream.c
@@ -3485,7 +3485,7 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
         if (u->peer.tries == 0 || !(u->conf->next_upstream & ft_type) ||
                 (r->method == NGX_HTTP_POST && !((r->uri.len == 1 &&
                         r->uri.data[r->uri.len - 1] == '/') ||
-                        (ngx_strcasecmp(r->uri.data, zlcf->url.data) == 0)))) {
+                        (ngx_strncasecmp(r->uri.data, zlcf->url.data, zlcf->url.len) == 0)))) {
 #if (NGX_HTTP_CACHE)
 
             if (u->cache_status == NGX_HTTP_CACHE_EXPIRED


### PR DESCRIPTION
Problem
In general, Nginx chooses the initial upstream MBS (where the login page is fetched) based on the client's source IP address.  When the chosen upstream MBS is down, Nginx is supposed to switch to other MBS; it works when the zimbraMailUrl is set to the default value '/'.  But, if the zimbraMailUrl is set to other than '/', such as '/zimbra' the former default value of the 'zimbraMailUrl', the Nginx does not failover the running MBS but returns 502 error.

This bug was introduced by the Bugzilla 79621.  The bug fix description said:
```
Added a check for HTTP POST requests to terminate the connection if the upstream server is down and if the request is not a auth request.
Web client auth request are HTTP POST request with URI '/' and can also include URL prefix from 'zimbraMailURL'.
```
But in fact, if the 'zimbraMailURL' was other than '/', the code compared not the *prefix* of the HTTP Post but the *entire* part of the request with the 'zimbraMailURL'.   As a result, the nginx coudn't detect the down of the upstream server.

Who needs this fix:
The system operating with multiple MBS servers and haveing a configuration of "zimbraMailURL" other than "/".

