### PR TITLE
 ZCS-6202: Updated the source URL to get the package from the Amavis …

### DIFF
--- a/thirdparty/amavisd/Makefile
+++ b/thirdparty/amavisd/Makefile
@@ -7,7 +7,7 @@ pname := amavisd
 uname := $(pname)-new
 pfile := $(uname)-$(pvers).tar.bz2
 psrc_file := $(SRC_DIR)/$(pfile)
-purl := http://www.ijs.si/software/amavisd/$(pfile)
+purl := --no-check-certificate https://www.ijs.si/software/amavisd/$(pfile)
 zname := zimbra-$(pname)
 zspec := $(pname).spec
 


### PR DESCRIPTION
…website

Added no certificate check because of the following error.
ERROR: cannot verify www.ijs.si's certificate, issued by 'CN=TERENA SSL CA 3,O=TERENA,L=Amsterdam,ST=Noord-Holland,C=NL':
  Unable to locally verify the issuer's authority.