### PR TITLE
ZCS-6180: Compilation error while creating build on ubuntu 18

### DIFF
--- a/thirdparty/altermime/Makefile
+++ b/thirdparty/altermime/Makefile
@@ -6,7 +6,7 @@ pvers := $(ALTMIME_VERSION)
 pname := altermime
 pfile := $(pname)-$(pvers).tar.gz
 psrc_file := $(SRC_DIR)/$(pfile)
-purl := http://www.pldaniels.com/altermime/altermime-0.3-dev.tar.gz
+purl := http://pldaniels.com/altermime/altermime-0.3-dev.tar.gz
 zname := zimbra-altermime
 zspec := $(pname).spec
 

--- a/thirdparty/altermime/zimbra-altermime/debian/patches/series
+++ b/thirdparty/altermime/zimbra-altermime/debian/patches/series
@@ -1,1 +1,0 @@
-qpe.patch


### PR DESCRIPTION
Did the following to fix that:
1: Update the default gcc version from gcc-7 to gcc-5.
2: Remove the patch mentioned in series file.