### PR TITLE
Allow to specify zmauth_zx in order to take into account different po…

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -37,8 +37,9 @@ static void ngx_zm_lookup_delete_cache_handler(mc_work_t *work);
 static ngx_str_t
 ngx_zm_lookup_get_user_route_key(ngx_pool_t *pool, ngx_log_t *log,
         ngx_str_t proto, ngx_str_t account_name, ngx_str_t client_ip);
-static ngx_str_t ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool,
-        ngx_log_t *log, ngx_str_t proto, ngx_str_t id, ngx_flag_t isAdmin);
+static ngx_str_t
+ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool, ngx_log_t *log, ngx_str_t proto,
+        ngx_str_t id, ngx_flag_t isAdmin, ngx_flag_t i);
 
 /* lookup from route lookup servlet */
 static void ngx_zm_lookup_dummy_handler(ngx_event_t *ev);
@@ -598,8 +599,9 @@ ngx_zm_lookup_route_from_cache (ngx_zm_lookup_ctx_t *ctx)
     work = ctx->work;
 
     if (work->auth_method == ZM_AUTHMETH_ZIMBRAID) {
-        key = ngx_zm_lookup_get_id_route_key(pool, log,
-                ZM_PROTO[work->protocol], work->username, work->isAdmin);
+        key = ngx_zm_lookup_get_id_route_key(
+                pool, log, ZM_PROTO[work->protocol], work->username,
+                work->isAdmin, work->isZx);
     } else {
         if (work->alias_check_stat == ZM_ALIAS_FOUND) {
             username = work->account_name;
@@ -994,6 +996,10 @@ ngx_zm_lookup_create_request(ngx_zm_lookup_ctx_t *ctx)
         len += sizeof ("Auth-Zimbra-Admin: True" CRLF) - 1;
     }
 
+    if (work->isZx) {
+        len += sizeof ("Auth-Zimbra-Zx: True" CRLF) - 1;
+    }
+
     if (IS_PROTO_WEB(work->protocol)) {
         len += sizeof("X-Proxy-Host: ") - 1 + work->virtual_host.len + sizeof(CRLF) - 1;
     }
@@ -1030,7 +1036,11 @@ ngx_zm_lookup_create_request(ngx_zm_lookup_ctx_t *ctx)
     b->last = ngx_sprintf(b->last, "Client-IP: %V" CRLF, &work->connection->addr_text);
     if (work->isAdmin) {
        b->last = ngx_cpymem(b->last, "Auth-Zimbra-Admin: True" CRLF, sizeof("Auth-Zimbra-Admin: True" CRLF) - 1);
-   }
+    }
+
+    if (work->isZx) {
+        b->last = ngx_cpymem(b->last, "Auth-Zimbra-Zx: True" CRLF, sizeof("Auth-Zimbra-Zx: True" CRLF) - 1);
+    }
 
     if (IS_PROTO_WEB(work->protocol)) {
         b->last = ngx_sprintf(b->last, "X-Proxy-Host: %V" CRLF, &work->virtual_host);
@@ -1981,8 +1991,9 @@ ngx_zm_lookup_cache_route(ngx_zm_lookup_ctx_t *ctx, ngx_str_t user, ngx_str_t ro
     work = ctx->work;
 
     if (work->auth_method == ZM_AUTHMETH_ZIMBRAID) {
-            key = ngx_zm_lookup_get_id_route_key(ctx->pool, log,
-                    ZM_PROTO[work->protocol], user, work->isAdmin);
+            key = ngx_zm_lookup_get_id_route_key(
+                    ctx->pool, log,
+                    ZM_PROTO[work->protocol], user, work->isAdmin, work->isZx);
     } else {
         if (zlcf->allow_unqualified == 0 && !is_login_qualified(user)) {
             key = ngx_zm_lookup_get_user_route_key(ctx->pool, log,
@@ -2131,8 +2142,9 @@ ngx_zm_lookup_get_http_alias_key (ngx_pool_t *pool, ngx_log_t *log,
 }
 
 static ngx_str_t
-ngx_zm_lookup_get_id_route_key (ngx_pool_t *pool, ngx_log_t *log,
-    ngx_str_t proto, ngx_str_t id, ngx_flag_t isAdmin)
+ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool, ngx_log_t *log,
+        ngx_str_t proto, ngx_str_t id, ngx_flag_t isAdmin,
+        ngx_flag_t isZx)
 {
     ngx_str_t       key;
     size_t          len;
@@ -2146,6 +2158,9 @@ ngx_zm_lookup_get_id_route_key (ngx_pool_t *pool, ngx_log_t *log,
         id.len;
     if (isAdmin) {
         len += sizeof("admin=1;") - 1;
+    }
+    if (isZx) {
+        len += sizeof("zx=1;") - 1;
     }
 
     key.data = ngx_palloc(pool, len);
@@ -2161,6 +2176,9 @@ ngx_zm_lookup_get_id_route_key (ngx_pool_t *pool, ngx_log_t *log,
     *p++ = ';';
     if (isAdmin) {
         p = ngx_cpymem(p, "admin=1;", sizeof("admin=1;") - 1);
+    }
+    if (isZx) {
+        p = ngx_cpymem(p, "zx=1;", sizeof("zx=1;") - 1);
     }
     p = ngx_cpymem(p, "id=", sizeof("id=") - 1);
     p = ngx_cpymem(p, id.data, id.len);

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -39,7 +39,7 @@ ngx_zm_lookup_get_user_route_key(ngx_pool_t *pool, ngx_log_t *log,
         ngx_str_t proto, ngx_str_t account_name, ngx_str_t client_ip);
 static ngx_str_t
 ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool, ngx_log_t *log, ngx_str_t proto,
-        ngx_str_t id, ngx_flag_t isAdmin, ngx_flag_t i);
+        ngx_str_t id, ngx_http_zmauth_t type);
 
 /* lookup from route lookup servlet */
 static void ngx_zm_lookup_dummy_handler(ngx_event_t *ev);
@@ -601,7 +601,7 @@ ngx_zm_lookup_route_from_cache (ngx_zm_lookup_ctx_t *ctx)
     if (work->auth_method == ZM_AUTHMETH_ZIMBRAID) {
         key = ngx_zm_lookup_get_id_route_key(
                 pool, log, ZM_PROTO[work->protocol], work->username,
-                work->isAdmin, work->isZx);
+                work->type);
     } else {
         if (work->alias_check_stat == ZM_ALIAS_FOUND) {
             username = work->account_name;
@@ -992,11 +992,9 @@ ngx_zm_lookup_create_request(ngx_zm_lookup_ctx_t *ctx)
         + sizeof ("X-Proxy-IP: ") - 1 + proxy_ip.len + sizeof(CRLF) - 1
         + sizeof ("Client-IP: ") - 1 + work->connection->addr_text.len + sizeof(CRLF) - 1;
 
-    if (work->isAdmin) {
+    if (work->type == admin) {
         len += sizeof ("Auth-Zimbra-Admin: True" CRLF) - 1;
-    }
-
-    if (work->isZx) {
+    } else if (work->type == zx) {
         len += sizeof ("Auth-Zimbra-Zx: True" CRLF) - 1;
     }
 
@@ -1034,11 +1032,9 @@ ngx_zm_lookup_create_request(ngx_zm_lookup_ctx_t *ctx)
     b->last = ngx_sprintf(b->last, "Auth-Login-Attempt: %d" CRLF, work->login_attempts);
     b->last = ngx_sprintf(b->last, "X-Proxy-IP: %V" CRLF, &proxy_ip);
     b->last = ngx_sprintf(b->last, "Client-IP: %V" CRLF, &work->connection->addr_text);
-    if (work->isAdmin) {
+    if (work->type == admin) {
        b->last = ngx_cpymem(b->last, "Auth-Zimbra-Admin: True" CRLF, sizeof("Auth-Zimbra-Admin: True" CRLF) - 1);
-    }
-
-    if (work->isZx) {
+    } else if (work->type == zx) {
         b->last = ngx_cpymem(b->last, "Auth-Zimbra-Zx: True" CRLF, sizeof("Auth-Zimbra-Zx: True" CRLF) - 1);
     }
 
@@ -1993,7 +1989,7 @@ ngx_zm_lookup_cache_route(ngx_zm_lookup_ctx_t *ctx, ngx_str_t user, ngx_str_t ro
     if (work->auth_method == ZM_AUTHMETH_ZIMBRAID) {
             key = ngx_zm_lookup_get_id_route_key(
                     ctx->pool, log,
-                    ZM_PROTO[work->protocol], user, work->isAdmin, work->isZx);
+                    ZM_PROTO[work->protocol], user, work->type);
     } else {
         if (zlcf->allow_unqualified == 0 && !is_login_qualified(user)) {
             key = ngx_zm_lookup_get_user_route_key(ctx->pool, log,
@@ -2143,8 +2139,7 @@ ngx_zm_lookup_get_http_alias_key (ngx_pool_t *pool, ngx_log_t *log,
 
 static ngx_str_t
 ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool, ngx_log_t *log,
-        ngx_str_t proto, ngx_str_t id, ngx_flag_t isAdmin,
-        ngx_flag_t isZx)
+        ngx_str_t proto, ngx_str_t id, ngx_http_zmauth_t type)
 {
     ngx_str_t       key;
     size_t          len;
@@ -2156,10 +2151,10 @@ ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool, ngx_log_t *log,
         sizeof(";") - 1 +
         sizeof("id=") - 1 +
         id.len;
-    if (isAdmin) {
+
+    if (type == zmauth_admin_console) {
         len += sizeof("admin=1;") - 1;
-    }
-    if (isZx) {
+    } else if (type == zmauth_zx) {
         len += sizeof("zx=1;") - 1;
     }
 
@@ -2174,10 +2169,9 @@ ngx_zm_lookup_get_id_route_key(ngx_pool_t *pool, ngx_log_t *log,
     p = ngx_cpymem(p, "proto=", sizeof("proto=") - 1);
     p = ngx_cpymem(p, proto.data, proto.len);
     *p++ = ';';
-    if (isAdmin) {
+    if (type == zmauth_admin_console) {
         p = ngx_cpymem(p, "admin=1;", sizeof("admin=1;") - 1);
-    }
-    if (isZx) {
+    } else if (type == zmauth_zx) {
         p = ngx_cpymem(p, "zx=1;", sizeof("zx=1;") - 1);
     }
     p = ngx_cpymem(p, "id=", sizeof("id=") - 1);

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.h
@@ -54,6 +54,14 @@ struct ngx_zm_lookup_work_s;
 
 typedef void (*ngx_zm_lookup_callback)(struct ngx_zm_lookup_work_s *);
 
+/* zmauth type */
+typedef enum {
+    zmauth_web_client,
+    zmauth_admin_console,
+    zmauth_zx
+} ngx_http_zmauth_t;
+
+
 struct ngx_zm_lookup_work_s {
     ngx_pool_t    *pool;
     ngx_log_t     *log;
@@ -61,8 +69,9 @@ struct ngx_zm_lookup_work_s {
     /* input */
     ngx_str_t      username;        /* the original username given by user */
     ngx_str_t      auth_id;         /* GSSAPI auth id (principal) */
-    ngx_flag_t     isAdmin;         /* whether is admin       */
-    ngx_flag_t     isZx;            /* is /zx/ to the dedicated handlers */
+
+    ngx_http_zmauth_t    type;     /* whether is web, admin or /zx/ */
+
     ngx_uint_t     protocol:3;      /* protocol               */
     ngx_uint_t     auth_method:4;   /* auth method            */
     ngx_uint_t     alias_check_stat:2; /* the alias-->account caching lookup status */

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.h
@@ -62,6 +62,7 @@ struct ngx_zm_lookup_work_s {
     ngx_str_t      username;        /* the original username given by user */
     ngx_str_t      auth_id;         /* GSSAPI auth id (principal) */
     ngx_flag_t     isAdmin;         /* whether is admin       */
+    ngx_flag_t     isZx;            /* is /zx/ to the dedicated handlers */
     ngx_uint_t     protocol:3;      /* protocol               */
     ngx_uint_t     auth_method:4;   /* auth method            */
     ngx_uint_t     alias_check_stat:2; /* the alias-->account caching lookup status */

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_upstream_zmauth_module.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_upstream_zmauth_module.c
@@ -20,13 +20,6 @@
 #include <ngx_http_upstream_zmauth_module.h>
 #include <ctype.h>
 
-/* zmauth type */
-enum ngx_http_zmauth_type {
-    zmauth_web_client,
-    zmauth_admin_console,
-    zmauth_zx
-};
-
 static char *ngx_http_upstream_fair_set_shm_size(ngx_conf_t *cf,
                                                  ngx_command_t *cmd, void *conf);
 static char * ngx_http_upstream_zmauth(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -48,7 +41,7 @@ static ngx_int_t ngx_http_upstream_init_admin_zmauth_peer(ngx_http_request_t *r,
 static ngx_int_t ngx_http_upstream_init_zx_zmauth_peer(ngx_http_request_t *r,
         ngx_http_upstream_srv_conf_t *us);
 static ngx_int_t ngx_http_upstream_do_init_zmauth_peer(ngx_http_request_t *r,
-        ngx_http_upstream_srv_conf_t *us, enum ngx_http_zmauth_type type);
+        ngx_http_upstream_srv_conf_t *us, ngx_http_zmauth_t type);
 static ngx_int_t ngx_http_upstream_get_zmauth_peer(ngx_peer_connection_t *pc,
         void *data);
 static void ngx_http_upstream_free_zmauth_peer(ngx_peer_connection_t *pc,
@@ -305,7 +298,7 @@ ngx_http_upstream_init_zx_zmauth_peer(ngx_http_request_t *r,
  */
 static ngx_int_t
 ngx_http_upstream_do_init_zmauth_peer(ngx_http_request_t *r,
-        ngx_http_upstream_srv_conf_t *us, enum ngx_http_zmauth_type type)
+        ngx_http_upstream_srv_conf_t *us, ngx_http_zmauth_t type)
 {
     ngx_http_upstream_zmauth_peer_data_t *zmp;
     struct sockaddr_in                   *sin;
@@ -430,12 +423,9 @@ ngx_http_upstream_do_init_zmauth_peer(ngx_http_request_t *r,
         } else {
             work->auth_method = ZM_AUTHMETH_USERNAME;
         }
-        if (type == zmauth_admin_console) {
-            work->isAdmin = 1;
-        }
-        if (type == zmauth_zx) {
-            work->isZx = 1;
-        }
+
+        work->type = type;
+
         ctx->work = work;
         ctx->connect = us->connect;
         ngx_zm_lookup(work);

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_upstream_zmauth_module.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_upstream_zmauth_module.c
@@ -23,7 +23,8 @@
 /* zmauth type */
 enum ngx_http_zmauth_type {
     zmauth_web_client,
-    zmauth_admin_console
+    zmauth_admin_console,
+    zmauth_zx
 };
 
 static char *ngx_http_upstream_fair_set_shm_size(ngx_conf_t *cf,
@@ -33,6 +34,9 @@ static char * ngx_http_upstream_zmauth(ngx_conf_t *cf, ngx_command_t *cmd,
 static char * ngx_http_upstream_zmauth_admin(ngx_conf_t *cf, ngx_command_t *cmd,
         void *conf);
 
+static char * ngx_http_upstream_zmauth_zx(ngx_conf_t *cf, ngx_command_t *cmd,
+        void *conf);
+
 static void *ngx_http_upstream_zmauth_create_srv_conf(ngx_conf_t *cf);
 static char *ngx_http_upstream_zmauth_merge_srv_conf(ngx_conf_t *cf,
         void *parent, void *child);
@@ -40,6 +44,8 @@ static char *ngx_http_upstream_zmauth_merge_srv_conf(ngx_conf_t *cf,
 static ngx_int_t ngx_http_upstream_init_zmauth_peer(ngx_http_request_t *r,
         ngx_http_upstream_srv_conf_t *us);
 static ngx_int_t ngx_http_upstream_init_admin_zmauth_peer(ngx_http_request_t *r,
+        ngx_http_upstream_srv_conf_t *us);
+static ngx_int_t ngx_http_upstream_init_zx_zmauth_peer(ngx_http_request_t *r,
         ngx_http_upstream_srv_conf_t *us);
 static ngx_int_t ngx_http_upstream_do_init_zmauth_peer(ngx_http_request_t *r,
         ngx_http_upstream_srv_conf_t *us, enum ngx_http_zmauth_type type);
@@ -119,6 +125,13 @@ static ngx_command_t ngx_http_upstream_zmauth_commands[] =
     { ngx_string("zmauth_admin"),
       NGX_HTTP_UPS_CONF|NGX_CONF_NOARGS,
       ngx_http_upstream_zmauth_admin,
+      0,
+      0,
+      NULL },
+
+    { ngx_string("zmauth_zx"),
+      NGX_HTTP_UPS_CONF|NGX_CONF_NOARGS,
+      ngx_http_upstream_zmauth_zx,
       0,
       0,
       NULL },
@@ -214,6 +227,20 @@ ngx_http_upstream_zmauth_admin(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
+static char *
+ngx_http_upstream_zmauth_zx(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_upstream_srv_conf_t *uscf;
+
+    uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
+    uscf->peer.init_upstream = ngx_http_upstream_init_zx_zmauth;
+
+    uscf->flags = NGX_HTTP_UPSTREAM_CREATE | NGX_HTTP_UPSTREAM_MAX_FAILS
+                  | NGX_HTTP_UPSTREAM_FAIL_TIMEOUT | NGX_HTTP_UPSTREAM_DOWN | NGX_HTTP_UPSTREAM_VERSION;
+
+    return NGX_CONF_OK;
+}
+
 /* This is the 'init_upstream' routine -- called when the main upstream
  configuration is initialized -- at this point, all the component servers
  in the upstream block should already be known, so that data-structures
@@ -241,6 +268,17 @@ ngx_http_upstream_init_admin_zmauth(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t
     return NGX_OK;
 }
 
+ngx_int_t
+ngx_http_upstream_init_zx_zmauth(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
+{
+    if (ngx_http_upstream_init_fair(cf, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    us->peer.init = ngx_http_upstream_init_zx_zmauth_peer;
+    return NGX_OK;
+}
+
 static ngx_int_t
 ngx_http_upstream_init_zmauth_peer(ngx_http_request_t *r,
         ngx_http_upstream_srv_conf_t *us)
@@ -253,6 +291,13 @@ ngx_http_upstream_init_admin_zmauth_peer(ngx_http_request_t *r,
         ngx_http_upstream_srv_conf_t *us)
 {
     return ngx_http_upstream_do_init_zmauth_peer(r, us, zmauth_admin_console);
+}
+
+static ngx_int_t
+ngx_http_upstream_init_zx_zmauth_peer(ngx_http_request_t *r,
+                                         ngx_http_upstream_srv_conf_t *us)
+{
+    return ngx_http_upstream_do_init_zmauth_peer(r, us, zmauth_zx);
 }
 
 /* This function is called when an incoming http request needs to be routed to
@@ -317,7 +362,7 @@ ngx_http_upstream_do_init_zmauth_peer(ngx_http_request_t *r,
     zmp->hash = 89;
     zmp->tries = 0;
 
-    if (type == zmauth_web_client) {
+    if (type == zmauth_web_client || type == zmauth_zx) {
         zmp->zmroutetype = zmauth_check_uri(r, &info);
         if (&zmp->fp && (zmp->zmroutetype == zmroutetype_authtoken) && zmauth_check_authtoken(r, &NGX_ZMAUTHTOKEN_VER, &ver)) {
         	zmp->fp.version = *((ngx_str_t*) ver);
@@ -387,6 +432,9 @@ ngx_http_upstream_do_init_zmauth_peer(ngx_http_request_t *r,
         }
         if (type == zmauth_admin_console) {
             work->isAdmin = 1;
+        }
+        if (type == zmauth_zx) {
+            work->isZx = 1;
         }
         ctx->work = work;
         ctx->connect = us->connect;

--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_upstream_zmauth_module.h
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/http/modules/ngx_http_upstream_zmauth_module.h
@@ -69,5 +69,8 @@ ngx_int_t ngx_http_upstream_init_zmauth(ngx_conf_t *cf,
 ngx_int_t ngx_http_upstream_init_admin_zmauth(ngx_conf_t *cf,
         ngx_http_upstream_srv_conf_t *us);
 
+ngx_int_t ngx_http_upstream_init_zx_zmauth(ngx_conf_t *cf,
+        ngx_http_upstream_srv_conf_t *us);
+
 #endif
 


### PR DESCRIPTION
This patch fixes the current issue with drive routing towards the new ports 8742 8743 introduced for drive.

The new upstream uses different ports (8742,8743) and the combination address:port returned by nginx-lookup handler extension doesn't match for nginx which fallback to "fair" algorithm instead of using the address and ports specified in the upstream.

In this pr i solve the issue by copying the exact same solution used by zmauth_admin which duplicates the command (zmauth to zmauth_admin) to populate an additional parameter which is sent to nginx-lookup-handler extension in mailboxd which can be used to differentiate normal https to admin https (7072) and return the correct combination address:port which completly match the upstreams.

Another solution could be to simply ignore the port returned by nginx-lookup-handler and use the one specified by the upstream but i ignore if they are others side effects.

configuration change: https://github.com/Zimbra/zm-nginx-conf/pull/11
lookup handler change: https://github.com/Zimbra/zm-nginx-lookup-store/pull/9

