### PR TITLE
Nginx memory leak fix

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_proxy_module.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/mail/ngx_mail_proxy_module.c
@@ -1742,6 +1742,13 @@ ngx_mail_proxy_upstream_error(ngx_mail_session_t *s)
         ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
                        "close mail proxy connection: %d",
                        s->proxy->upstream.connection->fd);
+#if (NGX_MAIL_SSL)
+
+        if (s->proxy->upstream.connection->ssl) {
+            s->proxy->upstream.connection->ssl->no_wait_shutdown = 1;
+            ngx_ssl_shutdown(s->proxy->upstream.connection);
+        }
+#endif
 
         ngx_close_connection(s->proxy->upstream.connection);
     }
@@ -1763,6 +1770,13 @@ ngx_mail_proxy_internal_server_error(ngx_mail_session_t *s)
         ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
                        "close mail proxy connection: %d",
                        s->proxy->upstream.connection->fd);
+#if (NGX_MAIL_SSL)
+
+        if (s->proxy->upstream.connection->ssl) {
+            s->proxy->upstream.connection->ssl->no_wait_shutdown = 1;
+            ngx_ssl_shutdown(s->proxy->upstream.connection);
+        }
+#endif
 
         ngx_close_connection(s->proxy->upstream.connection);
     }
@@ -2058,6 +2072,13 @@ static void ngx_mail_proxy_choke_session(ngx_mail_session_t *s)
         ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
                        "close mail proxy connection: %d",
                        s->proxy->upstream.connection->fd);
+#if (NGX_MAIL_SSL)
+
+        if (s->proxy->upstream.connection->ssl) {
+            s->proxy->upstream.connection->ssl->no_wait_shutdown = 1;
+            ngx_ssl_shutdown(s->proxy->upstream.connection);
+        }
+#endif
 
         ngx_close_connection(s->proxy->upstream.connection);
     }

--- a/thirdparty/openssl/zimbra-openssl/debian/rules
+++ b/thirdparty/openssl/zimbra-openssl/debian/rules
@@ -11,7 +11,7 @@ export DEB_LDFLAGS_MAINT_APPEND="-LOZCL -ROZCL -Wl,-rpath,OZCL"
 override_dh_auto_configure:
 	./Configure no-idea enable-ec_nistp_64_gcc_128 no-mdc2 no-rc5 no-ssl2 \
   no-hw --prefix=OZC --libdir=lib --openssldir=OZCE/ssl \
-  shared linux-x86_64 -g -O2 -DOPENSSL_NO_HEARTBEATS
+  shared linux-x86_64 -g -O2 -DOPENSSL_NO_HEARTBEATS -DOPENSSL_NO_BUF_FREELISTS
 
 override_dh_auto_build:
 	LD_RUN_PATH=OZCL make depend

--- a/thirdparty/openssl/zimbra-openssl/rpm/SPECS/openssl.spec
+++ b/thirdparty/openssl/zimbra-openssl/rpm/SPECS/openssl.spec
@@ -25,7 +25,7 @@ The Zimbra OpenSSL build allows for secure communication between various process
 %build
 ./Configure no-idea enable-ec_nistp_64_gcc_128 no-mdc2 no-rc5 no-ssl2 \
   no-hw --prefix=OZC --libdir=lib --openssldir=OZCE/ssl \
-  shared linux-x86_64 -g -O2 -DOPENSSL_NO_HEARTBEATS
+  shared linux-x86_64 -g -O2 -DOPENSSL_NO_HEARTBEATS -DOPENSSL_NO_BUF_FREELISTS
 LD_RUN_PATH=OZCL make depend
 LD_RUN_PATH=OZCL make all
 


### PR DESCRIPTION
The current nginx code alterations introduce a memory leak concerning the tearing down of SSL connections from the proxy to the upstream mailbox servers in the case of IMAP/POP3 connections.

The SSL data structures in memory related to the upstream connections are not freed when the upstream connection is brought down leading to a memory leak which grows over time in the worker processes.

The fix is to address that bit in the connection closing process, code which was already there in the code path used for successfully established connections to the upstream server but not for connections failing because of wrong credentials or other situations.

Also added is an additional compilation switch for the OpenSSL compilation which disables the freelist buffers, a concept introduced to mitigate slow malloc implementations once upon a time and which has since been removed from other SSL implementations and from the 1.1.x branch of OpenSSL.
Those buffers are used to recycle chunks of memory already allocated through malloc, chunks which are never actually release back to the OS, so their amount can grow over time, especially under load.
The switch added to the compilation options reverts to direct invocations to malloc/free.

This PR should address the bug at https://bugzilla.zimbra.com/show_bug.cgi?id=108015