### PR TITLE
Build the openjdk 8 for ubuntu-18

### DIFF
--- a/thirdparty/openjdk/Makefile
+++ b/thirdparty/openjdk/Makefile
@@ -41,7 +41,12 @@ getsrc:
 	tar cfz $(pfile) $(pname)-$(pvers) && \
 	mv $(pfile) .. && \
 	cd .. && \
-	rm -rf tmp \
+	rm -rf tmp && \
+	wget http://ftp.de.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jdk_7u161-2.6.12-1_amd64.deb && \
+        wget http://ftp.de.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jre_7u161-2.6.12-1_amd64.deb && \
+        wget http://ftp.de.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jre-headless_7u161-2.6.12-1_amd64.deb && \
+        wget http://ftp.de.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_1.5.2-2+b1_amd64.deb && \
+        dpkg -i openjdk-7-* libjpeg62-turbo* \
 	)
 
 pkgadd:

--- a/thirdparty/openjdk/UBUNTU.def
+++ b/thirdparty/openjdk/UBUNTU.def
@@ -3,11 +3,13 @@ openjdk.UBUNTU := libx11-dev x11proto-xext-dev libxext-dev \
 	x11proto-fixes-dev x11proto-record-dev libxtst-dev libxt-dev \
  	openjdk-7-jdk libcups2-dev libfreetype6-dev libasound2-dev \
  	ccache
+openjdk.UBUNTU18_64 := $(openjdk.UBUNTU)
 openjdk.UBUNTU16_64 := $(openjdk.UBUNTU)
 openjdk.UBUNTU14_64 := $(openjdk.UBUNTU)
 openjdk.UBUNTU12_64 := $(openjdk.UBUNTU)
 openjdk-purge.UBUNTU := libxt-dev libxtst-dev libxrender-dev libxext-dev libx11-dev \
 	libcups2-dev libfreetype6-dev libasound2-dev openjdk-7-jdk ccache
+openjdk-purge.UBUNTU18_64 := $(openjdk-purge.UBUNTU16_64)
 openjdk-purge.UBUNTU16_64 := $(openjdk-purge.UBUNTU) libsctp1 openjdk-7-jre-headless \
 	x11proto-fixes-dev x11proto-record-dev x11proto-render-dev x11proto-xext-dev \
 	x11proto-core-dev x11proto-input-dev xorg-sgml-doctools at-spi2-core \

--- a/thirdparty/openjdk/zimbra-openjdk/debian/rules
+++ b/thirdparty/openjdk/zimbra-openjdk/debian/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 export DEB_BUILD_OPTIONS=nocheck
+export CFLAGS="-w"
 
 %:
 	dh $@


### PR DESCRIPTION
Openjdk 11 has the issue with the code level on which API team is working.
To make the openjdk 8 to be compiled we need to have the boot of jdk 7 which is why we install the openjdk 7 from the compiled package available on debian.
Added the '-w' Flag with gcc to ingnore all the warnings not to be treated as error.