### PR TITLE
Hotfix/zbug 838: Proxies do not failover to the next mailbox server if the server is hung

### DIFF
--- a/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
+++ b/thirdparty/nginx/nginx-1.7.1-zimbra/src/core/ngx_zm_lookup.c
@@ -737,6 +737,7 @@ static ngx_flag_t
 ngx_zm_lookup_ssl_init_connection(ngx_ssl_t* ssl, ngx_connection_t *c)
 {
     ngx_int_t   rc;
+    ngx_int_t   marker = 20;
     ngx_zm_lookup_ctx_t *ctx = c->data;
 
     if (ngx_ssl_create_connection(ssl, c,
@@ -764,7 +765,15 @@ ngx_zm_lookup_ssl_init_connection(ngx_ssl_t* ssl, ngx_connection_t *c)
             ngx_zm_lookup_ssl_handshake(c);
             return ZM_LOOKUP_SSL_EVENT_FAILED;
         }
-    }while (rc == NGX_AGAIN);
+    }while (rc == NGX_AGAIN && --marker > 0);
+
+    if( 0 == marker )
+    {
+        ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
+                "zm lookup: ngx_zm_lookup_ssl_init_connection marker reached");
+        ngx_zm_lookup_ssl_handshake(c);
+        return ZM_LOOKUP_SSL_EVENT_FAILED;
+    }
 
     ngx_log_debug0 (NGX_LOG_DEBUG_ZIMBRA, c->log, 0,
             "zm lookup: ngx_zm_lookup_ssl_init_connection before call to ngx_zm_lookup_ssl_handshake");

--- a/thirdparty/nginx/zimbra-nginx/debian/changelog
+++ b/thirdparty/nginx/zimbra-nginx/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-nginx (VERSION-1zimbra8.7b11ZAPPEND) unstable; urgency=medium
+
+  * Patch for nginx bug ZBUG-838
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Thu, 07 Feb 2019 13:48:22 +0000 
+
 zimbra-nginx (VERSION-1zimbra8.7b10ZAPPEND) unstable; urgency=medium
 
   * Patch for nginx bug ZESC-821

--- a/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
+++ b/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's nginx build
 Name:               zimbra-nginx
 Version:            VERSION
-Release:            1zimbra8.7b9ZAPPEND
+Release:            1zimbra8.7b11ZAPPEND
 License:            MIT
 Source:             %{name}-%{version}.tar.gz
 BuildRequires:      pcre-devel, zlib-devel
@@ -17,7 +17,9 @@ URL:                http://nginx.org
 The Zimbra nginx build
 
 %changelog
-* Tue Nov 06 2018  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b10ZAPPEND
+* Thu Feb 07 2019  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b11ZAPPEND
+- Patch for nginx bug ZBUG-838
+- Tue Nov 06 2018  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b10ZAPPEND
 - Patch for nginx bug ZESC-821
 - Patch for nginx bug ZBUG-172
 * Thu Aug 30 2018  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b9ZAPPEND


### PR DESCRIPTION
**Problem:**
* Proxies do not failover to the next mailbox server if the mailbox server is hung.

**Approach and Fix:**
* Keep a marker on the number of retrials.

**Testing:**
* Tested it on mutiserver environment.

**Origin:**
* A highly escalated ticket from the two elite customers - PCCW and Orange.