### PR TITLE
ZCS-8289: add openssl fips build target in Make file

### DIFF
--- a/thirdparty/openssl/Makefile
+++ b/thirdparty/openssl/Makefile
@@ -22,7 +22,12 @@ $(psrc_file):
 setup:
 	$(generic-setup)
 
-build: setup build_$(PKG_EXT)
+build_fips:
+	$(WGET) -O /tmp/openssl-fips-2.0.16.tar.gz https://www.openssl.org/source/openssl-fips-2.0.16.tar.gz && \
+	$(CD) /tmp && $(TAR) xfz openssl-fips-2.0.16.tar.gz && \
+	$(CD) /tmp/openssl-fips-2.0.16 && ./config && $(MAKE) && $(MAKE) install
+
+build: setup build_fips build_$(PKG_EXT)
 
 build_rpm: specfile = SPECS/$(zspec)
 build_rpm: 


### PR DESCRIPTION
This PR adds code to download openssl-fips source and build the same.