### PR TITLE
ZBUG-1441 : Default openldap configuration files with incorrect permissions

### DIFF
--- a/thirdparty/openldap/zimbra-openldap/debian/changelog
+++ b/thirdparty/openldap/zimbra-openldap/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-openldap (VERSION-1zimbra8.8b2ZAPPEND) unstable; urgency=medium
+
+  * Fix for ZBUG-1441
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Tue, 09 Jun 2020 11:25:24 +0000
+
 zimbra-openldap (VERSION-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Update for OpenLDAP 2.4.49

--- a/thirdparty/openldap/zimbra-openldap/rpm/SPECS/openldap.spec
+++ b/thirdparty/openldap/zimbra-openldap/rpm/SPECS/openldap.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's openldap build
 Name:               zimbra-openldap
 Version:            VERSION
-Release:            1zimbra8.8b1ZAPPEND
+Release:            1zimbra8.8b2ZAPPEND
 License:            BSD
 Source:             %{name}-%{version}.tgz
 Patch0:             ITS5037.patch
@@ -21,6 +21,8 @@ URL:                http://www.openldap.org
 The Zimbra openldap build
 
 %changelog
+* Tue Jun 09 2020  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.8b2ZAPPEND
+- Fix for ZBUG-1441
 * Mon Feb 10 2020  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.8b1ZAPPEND
 - Update for OpenLDAP 2.4.49
 
@@ -155,6 +157,10 @@ The zimbra-lmdb-devel package contains the linking libraries and include files
 /opt/zimbra/common/etc
 /opt/zimbra/common/libexec
 /opt/zimbra/common/share/man
+%attr(644, root, root) /opt/zimbra/common/etc/openldap/slapd.conf
+%attr(644, root, root) /opt/zimbra/common/etc/openldap/slapd.conf.default
+%attr(644, root, root) /opt/zimbra/common/etc/openldap/slapd.ldif
+%attr(644, root, root) /opt/zimbra/common/etc/openldap/slapd.ldif.default
 %exclude /opt/zimbra/common/etc/openldap/ldap.conf
 %exclude /opt/zimbra/common/etc/openldap/ldap.conf.default
 %exclude /opt/zimbra/common/share/man/man1

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (1.0.4-1zimbra8.8b1ZAPPEND) unstable; urgency=low
+
+  * Fixed ZBUG-1441 in openldap
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Tue, 09 Jun 2020 00:00:00 +0000
+
 zimbra-ldap-components (1.0.3-1zimbra8.8b1ZAPPEND) unstable; urgency=low
 
   * Updated openldap 2.4.49

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.4.46-1zimbra8.7b3ZAPPEND), zimbra-openldap-server (>= 2.4.49-1zimbra8.8b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.4.49-1zimbra8.8b2ZAPPEND), zimbra-openldap-server (>= 2.4.49-1zimbra8.8b2ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,10 +1,10 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            1.0.3
+Version:            1.0.4
 Release:            ITERATIONZAPPEND
 License:            GPL-2
-Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.4.46-1zimbra8.7b3ZAPPEND
-Requires:           zimbra-openldap-server >= 2.4.49-1zimbra8.8b1ZAPPEND
+Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.4.49-1zimbra8.8b2ZAPPEND
+Requires:           zimbra-openldap-server >= 2.4.49-1zimbra8.8b2ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -16,6 +16,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Tue Jun 09 2020  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4
+- Fixed ZBUG-1441 in openldap
 * Tue Mar 17 2020  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3
 - Updated openldap to 2.4.49
 * Tue Sep 18 2018  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.2


### PR DESCRIPTION
NG-Backup is stopping because it cannot read files that have the wrong permissions.
Getting below warnings from backup notification. 
Warnings:
- File /opt/zimbra/common/etc/openldap/slapd.conf is not readable
- File /opt/zimbra/common/etc/openldap/slapd.conf.default is not readable
- File /opt/zimbra/common/etc/openldap/slapd.ldif is not readable
- File /opt/zimbra/common/etc/openldap/slapd.ldif.default is not readable
