### PR TITLE
ZBUG-2098: Fixes memory leak due to upstream IMAP/POP3 ssl connections

### DIFF
--- a/thirdparty/nginx/nginx-1.19.0-zimbra/src/mail/ngx_mail_proxy_module.c
+++ b/thirdparty/nginx/nginx-1.19.0-zimbra/src/mail/ngx_mail_proxy_module.c
@@ -1731,6 +1731,14 @@ ngx_mail_proxy_upstream_error(ngx_mail_session_t *s)
                        "close mail proxy connection: %d",
                        s->proxy->upstream.connection->fd);
 
+#if (NGX_MAIL_SSL)
+
+        if (s->proxy->upstream.connection->ssl) {
+            s->proxy->upstream.connection->ssl->no_wait_shutdown = 1;
+            ngx_ssl_shutdown(s->proxy->upstream.connection);
+        }
+#endif
+
         ngx_close_connection(s->proxy->upstream.connection);
     }
 
@@ -1751,6 +1759,14 @@ ngx_mail_proxy_internal_server_error(ngx_mail_session_t *s)
         ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
                        "close mail proxy connection: %d",
                        s->proxy->upstream.connection->fd);
+
+#if (NGX_MAIL_SSL)
+
+        if (s->proxy->upstream.connection->ssl) {
+            s->proxy->upstream.connection->ssl->no_wait_shutdown = 1;
+            ngx_ssl_shutdown(s->proxy->upstream.connection);
+        }
+#endif
 
         ngx_close_connection(s->proxy->upstream.connection);
     }
@@ -2046,6 +2062,14 @@ static void ngx_mail_proxy_choke_session(ngx_mail_session_t *s)
         ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
                        "close mail proxy connection: %d",
                        s->proxy->upstream.connection->fd);
+
+#if (NGX_MAIL_SSL)
+
+        if (s->proxy->upstream.connection->ssl) {
+            s->proxy->upstream.connection->ssl->no_wait_shutdown = 1;
+            ngx_ssl_shutdown(s->proxy->upstream.connection);
+        }
+#endif
 
         ngx_close_connection(s->proxy->upstream.connection);
     }


### PR DESCRIPTION
Relates to https://github.com/Zimbra/packages/pull/96
**Issue:**
- Memory leak concerning the tearing down of SSL connections from the proxy to the upstream mailbox servers in the case of IMAP/POP3 connections.

**Testing:**
- Tested by QA.