### PR TITLE
ZBUG-2125: malloc crash while throttling

### DIFF
--- a/thirdparty/nginx/nginx-1.19.0-zimbra/src/mail/ngx_mail_handler.c
+++ b/thirdparty/nginx/nginx-1.19.0-zimbra/src/mail/ngx_mail_handler.c
@@ -388,6 +388,10 @@ ngx_mail_init_session(ngx_connection_t *c)
 
     s->protocol = cscf->protocol->type;
 
+    if(s->ctx != NULL) {
+        return;
+    }
+
     s->ctx = ngx_pcalloc(c->pool, sizeof(void *) * ngx_mail_max_module);
     if (s->ctx == NULL) {
         ngx_mail_session_internal_server_error(s);


### PR DESCRIPTION
**Issues solved (Telnet reported):**
- Issue reported by telnet - malloc crash when throttle increase. When throttle count increases by limit, it can lead to malloc crash.

**Other crash solved:**
Dying worker processes, core dump even without the allow < limit
2021/05/07 16:14:17 [debug] 10673#0: ngx_mail_throttle_ip_success_handler: login_ip_max=10, mail_login_ip_max=10, mail_login_ip_imap_max=0, mail_login_ip_pop3_max=0
2021/05/07 16:14:17 [info] 10673#0: ip throttle:[127.0.0.1] allow [count:7, limit:10]
2021/05/07 16:14:17 [notice] 10672#0: signal 17 (SIGCHLD) received from 10673
2021/05/07 16:14:17 [alert] 10672#0: worker process 10673 exited on signal 11 (core dumped)

**Other issue solved:**
Additional throttling call and counter increase (functionally wrong).
In very slow systems, it is possible that counter is increased multiple times in a single connection.
Log:
2021/05/06 16:32:00 [debug] 17264#0: ngx_mail_throttle_ip_success_handler: login_ip_max=10, mail_login_ip_max=10, mail_login_ip_imap_max=0, mail_login_ip_pop3_max=0
2021/05/06 16:32:00 [info] 17264#0: ip throttle:[127.0.0.1] allow [count:5, limit:10]
2021/05/06 16:32:00 [debug] 17264#0: *4 event timer add: 16: 60000:94369248
2021/05/06 16:32:00 [debug] 17264#0: *4 SSL to write: 16
2021/05/06 16:32:00 [debug] 17264#0: *4 SSL_write: 16
2021/05/06 16:32:00 [debug] 17264#0: free: 000061900003E880, unused: 823
2021/05/06 16:32:00 [debug] 17264#0: memcache proto-handler consumed:3,rc:0
2021/05/06 16:32:00 [debug] 17264#0: ip throttle:127.0.0.1 is 6
2021/05/06 16:32:00 [debug] 17264#0: ngx_mail_throttle_ip_success_handler: login_ip_max=10, mail_login_ip_max=10, mail_login_ip_imap_max=0, mail_login_ip_pop3_max=0
2021/05/06 16:32:00 [info] 17264#0: ip throttle:[127.0.0.1] allow [count:6, limit:10]
2021/05/06 16:32:00 [debug] 17264#0: *4 event timer: 16, old: 94369248, new: 94369248
2021/05/06 16:32:00 [debug] 17264#0: *4 SSL to write: 16
2021/05/06 16:32:00 [debug] 17264#0: *4 SSL_write: 16

**Testing done:**
- Check on the Malloc crash.
- Check on slowness with double the load (600 threads).
- Login rejection testing in case of throttling.
- Basic IMAP commands.
- Single worker test.
- Test on default workers.