### PR TITLE
ZBUG-2723 : Generate anchor key required for DNSSEC

### DIFF
--- a/thirdparty/unbound/zimbra-unbound/debian/changelog
+++ b/thirdparty/unbound/zimbra-unbound/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-unbound (VERSION-1zimbra8.7b3ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-2723, Generate anchor key required for DNSSEC
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Tue, 12 Apr 2022 22:26:24 +0000
+
 zimbra-unbound (VERSION-1zimbra8.7b2ZAPPEND) unstable; urgency=medium
 
   * Upgraded dependency openssl to 1.1.1h

--- a/thirdparty/unbound/zimbra-unbound/debian/zimbra-unbound.postinst
+++ b/thirdparty/unbound/zimbra-unbound/debian/zimbra-unbound.postinst
@@ -1,0 +1,8 @@
+#!/bin/bash
+USER=$(whoami)
+if [ "$USER" = "zimbra" ]; then
+    /opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key"
+else
+   su - zimbra -c "/opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key""
+fi
+exit 0

--- a/thirdparty/unbound/zimbra-unbound/rpm/SPECS/unbound.spec
+++ b/thirdparty/unbound/zimbra-unbound/rpm/SPECS/unbound.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's Unbound build
 Name:               zimbra-unbound
 Version:            VERSION
-Release:            1zimbra8.7b2ZAPPEND
+Release:            1zimbra8.7b3ZAPPEND
 License:            BSD
 Source:             %{name}-%{version}.tar.gz
 Patch0:             log-facility.patch
@@ -17,6 +17,8 @@ The Zimbra Unbound build
 %define debug_package %{nil}
 
 %changelog
+* Tue Apr 12 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b3ZAPPEND
+- Fix ZBUG-2723, Generate anchor key required for DNSSEC
 * Fri Dec 02 2020 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b2ZAPPEND
 - Upgraded dependency openssl to 1.1.1h
 * Thu Sep 10 2020 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-ITERATIONZAPPEND
@@ -73,3 +75,12 @@ OZCI
 OZCL/*.a
 OZCL/*.la
 OZCL/*.so
+
+%post -p /bin/bash
+USER=$(whoami)
+if [ "$USER" = "zimbra" ]; then
+    /opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key"
+else
+   su - zimbra -c "/opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key""
+fi
+exit 0


### PR DESCRIPTION
**Problem :**  dnscache service does not support DNSSEC validation

**Fix :** This issue is due to anchor key file (/opt/zimbra/conf/root.key) is not present, to fix this need to generate anchor key file and add anchor key file path in /opt/zimbra/conf/unbound.conf.in

**Refer:**  Check the man page of "unbound-anchor" to get more details about the anchor key.

less  /opt/zimbra/common/share/man/man8/unbound-anchor.8

Related PR: https://github.com/Zimbra/zm-mailbox/pull/1251

