### PR TITLE
ZBUG-2738 : Updated proxy-components to 1.0.10 as part of nginx changes for ZBUG-2738

### DIFF
--- a/thirdparty/nginx/zimbra-nginx/debian/changelog
+++ b/thirdparty/nginx/zimbra-nginx/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-nginx (VERSION-1zimbra8.8b3ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-2738
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 06 May 2022 17:48:22 +0000
+
 zimbra-nginx (VERSION-1zimbra8.8b2ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-2299

--- a/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
+++ b/thirdparty/nginx/zimbra-nginx/rpm/SPECS/nginx.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's nginx build
 Name:               zimbra-nginx
 Version:            VERSION
-Release:            1zimbra8.8b2ZAPPEND
+Release:            1zimbra8.8b3ZAPPEND
 License:            MIT
 Source:             %{name}-%{version}.tar.gz
 BuildRequires:      pcre-devel, zlib-devel
@@ -17,6 +17,8 @@ URL:                http://nginx.org
 The Zimbra nginx build
 
 %changelog
+* Fri May 06 2022  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.8b3ZAPPEND
+- Fix ZBUG-2738
 * Wed Jul 07 2021  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.8b2ZAPPEND
 - Fix ZBUG-2299
 * Tue Jun 08 2021  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.8b1ZAPPEND

--- a/zimbra/proxy-components/zimbra-proxy-components/debian/changelog
+++ b/zimbra/proxy-components/zimbra-proxy-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-proxy-components (1.0.10-1zimbra8.8b1ZAPPEND) unstable; urgency=low
+
+  * Updated zimbra-nginx,Fix ZBUG-2738
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 06 May 2022 17:48:22 +0000
+
 zimbra-proxy-components (1.0.9-1zimbra8.8b1ZAPPEND) unstable; urgency=low
 
   * Updated zimbra-nginx to 1.20.0

--- a/zimbra/proxy-components/zimbra-proxy-components/debian/control
+++ b/zimbra/proxy-components/zimbra-proxy-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-proxy-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-proxy-base, zimbra-nginx (>= 1.20.0-1zimbra8.8b2ZAPPEND)
+ zimbra-proxy-base, zimbra-nginx (>= 1.20.0-1zimbra8.8b3ZAPPEND)
 Description: Zimbra components for proxy package
  Zimbra proxy components pulls in all the packages used by
  zimbra-proxy

--- a/zimbra/proxy-components/zimbra-proxy-components/rpm/SPECS/proxy-components.spec
+++ b/zimbra/proxy-components/zimbra-proxy-components/rpm/SPECS/proxy-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for proxy package
 Name:               zimbra-proxy-components
-Version:            1.0.9
+Version:            1.0.10
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-proxy-base, zimbra-nginx >= 1.20.0-1zimbra8.8b2ZAPPEND
+Requires:           zimbra-proxy-base, zimbra-nginx >= 1.20.0-1zimbra8.8b3ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -11,6 +11,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Fri May 06 2022  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.10
+- Updated zimbra-nginx,Fix ZBUG-2738
 * Sun Jul 25 2021  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.9
 - Updated zimbra-nginx to 1.20.0
 * Thu Jan 21 2021  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.8


### PR DESCRIPTION
Updated proxy-components to 1.0.10 as part of nginx changes for ZBUG-2738
Updated zimbra-nginx  changelog as part of nginx changes for ZBUG-2738