### PR TITLE
ZCS-11941 : Don't generate anchor key from unbound post install script

### DIFF
--- a/thirdparty/unbound/zimbra-unbound/debian/changelog
+++ b/thirdparty/unbound/zimbra-unbound/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-unbound (VERSION-1zimbra8.7b4ZAPPEND) unstable; urgency=medium
+
+  * Fix ZCS-11941, remove anchor key generation
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Sat, 20 Aug 2022 22:26:24 +0000
+
 zimbra-unbound (VERSION-1zimbra8.7b3ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-2723, Generate anchor key required for DNSSEC

--- a/thirdparty/unbound/zimbra-unbound/debian/zimbra-unbound.postinst
+++ b/thirdparty/unbound/zimbra-unbound/debian/zimbra-unbound.postinst
@@ -1,8 +1,0 @@
-#!/bin/bash
-USER=$(whoami)
-if [ "$USER" = "zimbra" ]; then
-    /opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key"
-else
-   su - zimbra -c "/opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key""
-fi
-exit 0

--- a/thirdparty/unbound/zimbra-unbound/rpm/SPECS/unbound.spec
+++ b/thirdparty/unbound/zimbra-unbound/rpm/SPECS/unbound.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's Unbound build
 Name:               zimbra-unbound
 Version:            VERSION
-Release:            1zimbra8.7b3ZAPPEND
+Release:            1zimbra8.7b4ZAPPEND
 License:            BSD
 Source:             %{name}-%{version}.tar.gz
 Patch0:             log-facility.patch
@@ -17,6 +17,8 @@ The Zimbra Unbound build
 %define debug_package %{nil}
 
 %changelog
+* Sat Aug 20 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b4ZAPPEND
+- Fix ZCS-11941, remove anchor key generation
 * Tue Apr 12 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b3ZAPPEND
 - Fix ZBUG-2723, Generate anchor key required for DNSSEC
 * Fri Dec 02 2020 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b2ZAPPEND
@@ -75,12 +77,3 @@ OZCI
 OZCL/*.a
 OZCL/*.la
 OZCL/*.so
-
-%post -p /bin/bash
-USER=$(whoami)
-if [ "$USER" = "zimbra" ]; then
-    /opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key"
-else
-   su - zimbra -c "/opt/zimbra/common/sbin/unbound-anchor -a "/opt/zimbra/conf/root.key""
-fi
-exit 0

--- a/zimbra/dnscache-components/zimbra-dnscache-components/debian/changelog
+++ b/zimbra/dnscache-components/zimbra-dnscache-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-dnscache-components (1.0.4-1zimbra8.7b1ZAPPEND) unstable; urgency=medium
+
+  * Fix ZCS-11941, Updated zimbra-unbound
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Sat, 20 Aug 2022 00:00:00 +0000
+
 zimbra-dnscache-components (1.0.3-1zimbra8.7b1ZAPPEND) unstable; urgency=medium
 
   * Fix for ZBUG-2723,Updated zimbra-unbound

--- a/zimbra/dnscache-components/zimbra-dnscache-components/debian/control
+++ b/zimbra/dnscache-components/zimbra-dnscache-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-dnscache-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-dnscache-base, zimbra-unbound (>= 1.11.0-1zimbra8.7b3ZAPPEND)
+ zimbra-dnscache-base, zimbra-unbound (>= 1.11.0-1zimbra8.7b4ZAPPEND)
 Description: Zimbra components for dnscache package
  Zimbra dnscache components pulls in all the packages used by
  zimbra-dnscache

--- a/zimbra/dnscache-components/zimbra-dnscache-components/rpm/SPECS/dnscache-components.spec
+++ b/zimbra/dnscache-components/zimbra-dnscache-components/rpm/SPECS/dnscache-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for dnscache package
 Name:               zimbra-dnscache-components
-Version:            1.0.3
+Version:            1.0.4
 Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-dnscache-base, zimbra-unbound >= 1.11.0-1zimbra8.7b3ZAPPEND
+Requires:           zimbra-dnscache-base, zimbra-unbound >= 1.11.0-1zimbra8.7b4ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -11,6 +11,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Sat Aug 20 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4
+- Fix ZCS-11941, Updated zimbra-unbound
 * Fri May 20 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3
 - Fix for ZBUG-2723,Updated zimbra-unbound
 * Sat Dec 05 2020 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.2


### PR DESCRIPTION
unbound post install script not able to generate anchor key in /opt/zimbra/conf because at the time of unbound pacakge installation /opt/zimbra/conf directory not exist. We can remove generate anchor key from post install script. We already handling this in zmdnscachectl https://github.com/Zimbra/zm-core-utils/blob/develop/src/bin/zmdnscachectl#L74