### PR TITLE
ZBUG-1457 : Fix regex error for amavisd restart

### DIFF
--- a/thirdparty/amavisd/patches/zbug-1457.patch
+++ b/thirdparty/amavisd/patches/zbug-1457.patch
@@ -1,0 +1,12 @@
+diff -ruN a/amavisd b/amavisd
+--- a/amavisd	2022-08-22 09:25:28.945660379 +0000
++++ b/amavisd	2022-08-22 09:26:59.919428184 +0000
+@@ -28124,7 +28124,7 @@
+         my $f = $bare_fnames->[$k];  my $multi = 0;
+         if ($one_at_a_time) {  # glob templates may be substrings anywhere
+           local($1);  @query_expanded = @query_template;  # start afresh
+-          s{ ( {} (?: / \* )? | \* ) }
++	   s{ ( \{\} (?: / \* )? | \* ) }
+            { $1 eq '{}'   ? "$tempdir/parts"
+            : $1 eq '{}/*' ? ($multi=1,"$tempdir/parts/$f")
+            : $1 eq '*'    ? ($multi=1,$f)  : $1

--- a/thirdparty/amavisd/zimbra-amavisd/debian/changelog
+++ b/thirdparty/amavisd/zimbra-amavisd/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-amavisd (VERSION-1zimbra8.7b2ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-1457
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Aug 2022 22:26:24 +0000
+
 zimbra-amavisd (VERSION-ITERATIONZAPPEND) unstable; urgency=medium
 
   * Initial Release.

--- a/thirdparty/amavisd/zimbra-amavisd/debian/patches/series
+++ b/thirdparty/amavisd/zimbra-amavisd/debian/patches/series
@@ -3,3 +3,4 @@ amavis-mc.patch
 perl-path.patch
 socketpath.patch
 zmq-sock.patch
+zbug-1457.patch

--- a/thirdparty/amavisd/zimbra-amavisd/rpm/SPECS/amavisd.spec
+++ b/thirdparty/amavisd/zimbra-amavisd/rpm/SPECS/amavisd.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's amavisd build
 Name:               zimbra-amavisd
 Version:            VERSION
-Release:            ITERATIONZAPPEND
+Release:            1zimbra8.7b2ZAPPEND
 License:            GPL-2
 Source:             %{name}-%{version}.tar.bz2
 Patch0:             amavisd.patch
@@ -9,6 +9,7 @@ Patch1:             amavis-mc.patch
 Patch2:             perl-path.patch
 Patch3:             socketpath.patch
 Patch4:             zmq-sock.patch
+Patch5:             zbug-1457.patch
 Requires:           perl, zimbra-mta-base
 AutoReqProv:        no
 URL:                http://www.ijs.si/software/amavisd/
@@ -25,6 +26,7 @@ The Zimbra amavisd build
 %patch2 -p1
 %patch3 -p1
 %patch4 -p1
+%patch5 -p1
 
 %build
 
@@ -40,3 +42,7 @@ cp amavisd-snmp-subagent-zmq ${RPM_BUILD_ROOT}OZC/sbin
 %files
 %defattr(-,root,root)
 OZC/sbin
+
+%changelog
+* Mon Aug 22 2022  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b2ZAPPEND
+- Fix ZBUG-1457

--- a/zimbra/mta-components/zimbra-mta-components/debian/changelog
+++ b/zimbra/mta-components/zimbra-mta-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-mta-components (1.0.16-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-1457, updated zimbra-amavisd
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Aug 2022 22:26:24 +0000
+
 zimbra-mta-components (1.0.15-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Updated zimbra-clamav,zimbra-spamassassin-rules,zimbra-perl-mail-spamassassin

--- a/zimbra/mta-components/zimbra-mta-components/debian/control
+++ b/zimbra/mta-components/zimbra-mta-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-mta-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- sqlite3, zimbra-mta-base, zimbra-altermime, zimbra-amavisd,
+ sqlite3, zimbra-mta-base, zimbra-altermime, zimbra-amavisd (>= 2.10.1-1zimbra8.7b2ZAPPEND),
  zimbra-clamav (>= 0.103.3-1zimbra8.8b3ZAPPEND),
  zimbra-clamav-db, zimbra-cluebringer, zimbra-mariadb (>= 10.1.25-1zimbra8.7b3ZAPPEND),
  zimbra-opendkim (>= 2.10.3-1zimbra8.7b5ZAPPEND), zimbra-perl-mail-spamassassin (>= 3.4.6-1zimbra8.8b3ZAPPEND),

--- a/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
+++ b/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for MTA package
 Name:               zimbra-mta-components
-Version:            1.0.15
+Version:            1.0.16
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
-Requires:           sqlite, zimbra-mta-base, zimbra-altermime, zimbra-amavisd
+Requires:           sqlite, zimbra-mta-base, zimbra-altermime, zimbra-amavisd >= 2.10.1-1zimbra8.7b2ZAPPEND
 Requires:           zimbra-clamav >= 0.103.3-1zimbra8.8b3ZAPPEND, zimbra-clamav-db
 Requires:           zimbra-cluebringer, zimbra-mariadb >= 10.1.25-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-opendkim >= 2.10.3-1zimbra8.7b5ZAPPEND, zimbra-perl-mail-spamassassin >= 3.4.6-1zimbra8.8b3ZAPPEND
@@ -20,6 +20,8 @@ Zimbra mta components pulls in all the packages used by
 zimbra-mta
 
 %changelog
+* Mon Aug 22 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.16
+- Fix ZBUG-1457, updated zimbra-amavisd
 * Fri May 20 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.15
 - Updated zimbra-clamav,zimbra-spamassassin-rules,zimbra-perl-mail-spamassassin
 * Tue Aug 17 2021 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.14


### PR DESCRIPTION
**Problem :** 
$ zmamavisdctl restart
Stopping amavisd... done.
Stopping amavisd-mc... done.
Starting amavisd-mc...done.
Starting amavisd...Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/ ( { <-- HERE } (?: / \* )? | \* ) / at (eval 100) line 784, <DATA> line 755.
done.