### PR TITLE
ZBUG-3017: added pax,spax in os-requirements for RHEL/CentOS/Oracle/Rocky Linux

### DIFF
--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (3.0.15-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-3017, Updated core-components to 3.0.15
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Sep 2022 00:00:00 +0000
+
 zimbra-core-components (3.0.14-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix for ZCS-11689, Upgraded OpenSSL to 1.1.1q

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-core-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-base, zimbra-os-requirements, zimbra-perl (>= 1.0.5-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
+ zimbra-base, zimbra-os-requirements (>= 1.0.2-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.5-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
  zimbra-openssl (>= 1.1.1q-1zimbra8.7b4ZAPPEND), zimbra-curl (>= 7.49.1-1zimbra8.7b3ZAPPEND), zimbra-cyrus-sasl (>= 2.1.28-1zimbra8.7b3ZAPPEND),
  zimbra-rsync,
  zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-prepflog,

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            3.0.14
+Version:            3.0.15
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-base, zimbra-os-requirements, zimbra-perl >= 1.0.5-1zimbra8.7b1ZAPPEND
+Requires:           zimbra-base, zimbra-os-requirements >= 1.0.2-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.5-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-pflogsumm
 Requires:           zimbra-openssl >= 1.1.1q-1zimbra8.7b4ZAPPEND,zimbra-curl >= 7.49.1-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b3ZAPPEND
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Mon Sep 12 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.15
+- Fix ZBUG-3017, Updated core-components to 3.0.15
 * Mon Jul 11 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.14
 - Fix for ZCS-11689, Upgraded OpenSSL to 1.1.1q
 * Thu Jul 07 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.13

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (2.0.9-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-3017, Updated core-components to 3.0.15
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Sep 2022 00:00:00 +000
+
 zimbra-ldap-components (2.0.8-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix for ZCS-11689, Upgraded OpenSSL to 1.1.1q and core-components to 3.0.14

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -2,7 +2,7 @@ zimbra-ldap-components (2.0.9-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-3017, Updated core-components to 3.0.15
 
- -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Sep 2022 00:00:00 +000
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Sep 2022 00:00:00 +0000
 
 zimbra-ldap-components (2.0.8-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openldap-server (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openssl (>= 1.1.1q-1zimbra8.7b4ZAPPEND), zimbra-openssl-lib (>= 1.1.1q-1zimbra8.7b4ZAPPEND), zimbra-core-components (>= 3.0.14-1zimbra8.8b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openldap-server (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openssl (>= 1.1.1q-1zimbra8.7b4ZAPPEND), zimbra-openssl-lib (>= 1.1.1q-1zimbra8.7b4ZAPPEND), zimbra-core-components (>= 3.0.15-1zimbra8.8b1ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            2.0.8
+Version:            2.0.9
 Release:            ITERATIONZAPPEND
 License:            GPL-2
 Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.4.59-1zimbra8.8b5ZAPPEND
 Requires:           zimbra-openldap-server >= 2.4.59-1zimbra8.8b5ZAPPEND
 Requires:           zimbra-openssl >= 1.1.1q-1zimbra8.7b4ZAPPEND, zimbra-openssl-libs >= 1.1.1q-1zimbra8.7b4ZAPPEND
-Requires:           zimbra-core-components >= 3.0.14-1zimbra8.8b1ZAPPEND
+Requires:           zimbra-core-components >= 3.0.15-1zimbra8.8b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -18,6 +18,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Mon Sep 12 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.9
+- Fix ZBUG-3017, Updated core-components to 3.0.15
 * Mon Jul 11 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.8
 - Fix for ZCS-11689, Upgraded OpenSSL to 1.1.1q and core-components to 3.0.14
 * Thu Jul 07 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.7

--- a/zimbra/os-requirements/RHEL.def
+++ b/zimbra/os-requirements/RHEL.def
@@ -1,2 +1,3 @@
-osdeps.RHEL7_64 := nmap-ncat
+osdeps.RHEL8_64 := nmap-ncat, spax
+osdeps.RHEL7_64 := nmap-ncat, pax
 osdeps.RHEL6_64 := nc

--- a/zimbra/os-requirements/UBUNTU.def
+++ b/zimbra/os-requirements/UBUNTU.def
@@ -1,3 +1,5 @@
+osdeps.UBUNTU20_64 := libgmp10, libperl5.30
+osdeps.UBUNTU18_64 := libgmp10, libperl5.26
 osdeps.UBUNTU16_64 := libgmp10, libperl5.22
 osdeps.UBUNTU14_64 := libgmp10, libperl5.18
 osdeps.UBUNTU12_64 := libgmp3c2, libperl5.14

--- a/zimbra/os-requirements/zimbra-os-requirements/debian/changelog
+++ b/zimbra/os-requirements/zimbra-os-requirements/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-os-requirements (1.0.2-1zimbra8.7b1ZAPPEND) unstable; urgency=low
+
+  * Fix ZBUG-3017
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Sep 2022 00:00:00 +0000
+
 zimbra-os-requirements (1.0.1-ITERATIONZAPPEND) unstable; urgency=low
 
   * Add lsb-release to the required packages for Debian

--- a/zimbra/os-requirements/zimbra-os-requirements/rpm/SPECS/os-requirements.spec
+++ b/zimbra/os-requirements/zimbra-os-requirements/rpm/SPECS/os-requirements.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra OS Requirements
 Name:               zimbra-os-requirements
-Version:            1.0.0
-Release:            ITERATIONZAPPEND
+Version:            1.0.2
+Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
@@ -15,5 +15,9 @@ AutoReqProv:        no
 %description
 Zimbra OS requirements is used as a simple method to pull in all
 OS required core packages
+
+%changelog
+* Mon Sep 12 2022  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b1ZAPPEND
+- Fix ZBUG-3017
 
 %files


### PR DESCRIPTION
**Problem:**
zimbra-os-requirements rpm package doesn't have dependency pax but debian package has dependency on pax. So add pax,spax in os-requirements for RHEL/CentOS/Oracle/Rocky Linux
```
# rpm -qpR zimbra-os-requirements-1.0.0-1zimbra8.7b1.el6.x86_64.rpm
coreutils
expat
file
gmp
libaio
libidn
libstdc++
pcre
perl
perl-core
sudo
sysstat
unzip
zimbra-base
perl-Socket6
nc
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1


# rpm -qpR zimbra-os-requirements-1.0.0-1zimbra8.7b1.el7.x86_64.rpm
coreutils
expat
file
gmp
libaio
libidn
libstdc++
pcre
perl
perl-core
sudo
sysstat
unzip
zimbra-base
perl-Socket6
nmap-ncat
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1

# rpm -qpR zimbra-os-requirements-1.0.0-1zimbra8.7b1.el8.x86_64.rpm
coreutils
expat
file
gmp
libaio
libidn
libstdc++
pcre
perl
perl-Socket6
perl-core
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
sudo
sysstat
unzip
zimbra-base

# dpkg -I zimbra-os-requirements_1.0.1-1zimbra8.7b1.16.04_all.deb
 new Debian package, version 2.0.
 size 1680 bytes: control archive=588 bytes.
     543 bytes,    11 lines      control              
     172 bytes,     2 lines      md5sums              
 Package: zimbra-os-requirements
 Version: 1.0.1-1zimbra8.7b1.16.04
 Architecture: all
 Maintainer: Zimbra Packaging Services <packaging-devel@zimbra.com>
 Installed-Size: 8
 Depends: coreutils, file, libaio1, libexpat1, libidn11, libpcre3, libstdc++6, lsb-release, netcat-openbsd, pax, perl, procps, resolvconf, sudo, sysstat, unzip, zimbra-base, libsocket6-perl, libgmp10, libperl5.22
 Section: mail
 Priority: optional
 Description: Zimbra OS Requirements
  Zimbra OS requirements is used as a simple method to pull in all
  OS required core packages

# dpkg -I zimbra-os-requirements_1.0.1-1zimbra8.7b1.18.04_all.deb
   new Debian package, version 2.0.
   size 1760 bytes: control archive=672 bytes.
       543 bytes,    11 lines      control              
       172 bytes,     2 lines      md5sums              
   Package: zimbra-os-requirements
   Version: 1.0.1-1zimbra8.7b1.18.04
   Architecture: all
   Maintainer: Zimbra Packaging Services <packaging-devel@zimbra.com>
   Installed-Size: 8
   Depends: coreutils, file, libaio1, libexpat1, libidn11, libpcre3, libstdc++6, lsb-release, netcat-openbsd, pax, perl, procps, resolvconf, sudo, sysstat, unzip, zimbra-base, libsocket6-perl, libgmp10, libperl5.26
   Section: mail
   Priority: optional
   Description: Zimbra OS Requirements
    Zimbra OS requirements is used as a simple method to pull in all
    OS required core packages
	
# dpkg -I zimbra-os-requirements_1.0.1-1zimbra8.7b1.20.04_all.deb
	 new Debian package, version 2.0.
	 size 1760 bytes: control archive=672 bytes.
	     543 bytes,    11 lines      control              
	     172 bytes,     2 lines      md5sums              
	 Package: zimbra-os-requirements
	 Version: 1.0.1-1zimbra8.7b1.20.04
	 Architecture: all
	 Maintainer: Zimbra Packaging Services <packaging-devel@zimbra.com>
	 Installed-Size: 8
	 Depends: coreutils, file, libaio1, libexpat1, libidn11, libpcre3, libstdc++6, lsb-release, netcat-openbsd, pax, perl, procps, resolvconf, sudo, sysstat, unzip, zimbra-base, libsocket6-perl, libgmp10, libperl5.30
	 Section: mail
	 Priority: optional
	 Description: Zimbra OS Requirements
	  Zimbra OS requirements is used as a simple method to pull in all
	  OS required core packages
```

**Fix:**
added pax as dependency for oracle 7/rhel 7/centos 7
added spax as dependency for oracle 8/rhel 8/centos 8/ Rocky Linux 8