### PR TITLE
ZBUG-3126 : Compile apache with pcre

### DIFF
--- a/thirdparty/httpd/zimbra-httpd/debian/changelog
+++ b/thirdparty/httpd/zimbra-httpd/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-httpd (VERSION-1zimbra8.7b4ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-3126
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 23 Nov 2022 22:26:24 +0000
+
 zimbra-httpd (VERSION-1zimbra8.7b3ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-2819, Upgraded Apache to 2.4.54

--- a/thirdparty/httpd/zimbra-httpd/debian/rules
+++ b/thirdparty/httpd/zimbra-httpd/debian/rules
@@ -16,6 +16,7 @@ override_dh_auto_configure:
 	--datadir=/opt/zimbra/data/httpd \
 	--enable-so \
 	--with-mpm=event \
+	--with-pcre=/usr/bin/pcre-config \
 	--enable-mpms-shared="all"
 
 override_dh_strip:

--- a/thirdparty/httpd/zimbra-httpd/rpm/SPECS/httpd.spec
+++ b/thirdparty/httpd/zimbra-httpd/rpm/SPECS/httpd.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's Apache HTTPD build
 Name:               zimbra-httpd
 Version:            VERSION
-Release:            1zimbra8.7b3ZAPPEND
+Release:            1zimbra8.7b4ZAPPEND
 License:            Apache-2.0
 Source:             %{name}-%{version}.tar.bz2
 BuildRequires:      zimbra-apr-devel
@@ -19,6 +19,8 @@ The Zimbra Apache HTTPD build
 %define debug_package %{nil}
 
 %changelog
+* Wed Nov 23 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b4ZAPPEND
+- Fix ZBUG-3126
 * Tue Oct 18 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b3ZAPPEND
 - Fix ZBUG-2819, Upgraded Apache to 2.4.54
 * Tue Mar 15 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b3ZAPPEND
@@ -50,6 +52,7 @@ CFLAGS="-O2 -g"; export CFLAGS; \
   --datadir=/opt/zimbra/data/httpd \
   --enable-so \
   --with-mpm=event \
+  --with-pcre=/usr/bin/pcre-config \
   --enable-mpms-shared="all"
 make
 

--- a/zimbra/apache-components/zimbra-apache-components/debian/changelog
+++ b/zimbra/apache-components/zimbra-apache-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-apache-components (2.0.9-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-3126
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 23 Nov 2022 22:26:24 +0000
+
 zimbra-apache-components (2.0.8-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-2819, Upgraded Apache to 2.4.54

--- a/zimbra/apache-components/zimbra-apache-components/debian/control
+++ b/zimbra/apache-components/zimbra-apache-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-apache-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-apache-base, zimbra-httpd (>= 2.4.54-1zimbra8.7b3ZAPPEND), zimbra-php (>= 7.4.27-1zimbra8.7b3ZAPPEND)
+ zimbra-apache-base, zimbra-httpd (>= 2.4.54-1zimbra8.7b4ZAPPEND), zimbra-php (>= 7.4.27-1zimbra8.7b3ZAPPEND)
 Description: Zimbra components for apache package
  Zimbra apache components pulls in all the packages used by
  zimbra-apache

--- a/zimbra/apache-components/zimbra-apache-components/rpm/SPECS/apache-components.spec
+++ b/zimbra/apache-components/zimbra-apache-components/rpm/SPECS/apache-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for apache package
 Name:               zimbra-apache-components
-Version:            2.0.8
+Version:            2.0.9
 Release:            1zimbra8.8b1ZAPPEND 
 License:            GPL-2
-Requires:           zimbra-apache-base, zimbra-httpd >= 2.4.54-1zimbra8.7b3ZAPPEND, zimbra-php >= 7.4.27-1zimbra8.7b3ZAPPEND
+Requires:           zimbra-apache-base, zimbra-httpd >= 2.4.54-1zimbra8.7b4ZAPPEND, zimbra-php >= 7.4.27-1zimbra8.7b3ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -15,6 +15,8 @@ Zimbra apache components pulls in all the packages used by
 zimbra-apache
 
 %changelog
+* Wed Nov 23 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.9
+- Fix ZBUG-3126
 * Tue Oct 18 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.8
 - Fix ZBUG-2819, Upgraded Apache to 2.4.54
 * Tue Mar 15 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.7

--- a/zimbra/spell-components/zimbra-spell-components/debian/changelog
+++ b/zimbra/spell-components/zimbra-spell-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-spell-components (2.0.10-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Fix ZBUG-3126
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 23 Nov 2022 22:26:24 +0000
+
 zimbra-spell-components (2.0.9-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-2819, Upgraded Apache to 2.4.54

--- a/zimbra/spell-components/zimbra-spell-components/debian/control
+++ b/zimbra/spell-components/zimbra-spell-components/debian/control
@@ -11,7 +11,7 @@ Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-spell-base, zimbra-aspell-ar, zimbra-aspell-ca, zimbra-aspell-da, zimbra-aspell-de,
  zimbra-aspell-en, zimbra-aspell-es, zimbra-aspell-fr, zimbra-aspell-hi,
  zimbra-aspell-hu, zimbra-aspell-it, zimbra-aspell-nl, zimbra-aspell-pl,
- zimbra-aspell-pt-br, zimbra-aspell-ru, zimbra-aspell-sv, zimbra-httpd (>= 2.4.54-1zimbra8.7b3ZAPPEND),
+ zimbra-aspell-pt-br, zimbra-aspell-ru, zimbra-aspell-sv, zimbra-httpd (>= 2.4.54-1zimbra8.7b4ZAPPEND),
  zimbra-php (>= 7.4.27-1zimbra8.7b3ZAPPEND), zimbra-aspell-zimbra
 Description: Zimbra components for spell package
  Zimbra spell components pulls in all the packages used by

--- a/zimbra/spell-components/zimbra-spell-components/rpm/SPECS/spell-components.spec
+++ b/zimbra/spell-components/zimbra-spell-components/rpm/SPECS/spell-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for spell package
 Name:               zimbra-spell-components
-Version:            2.0.9
+Version:            2.0.10
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-spell-base, zimbra-aspell-ar, zimbra-aspell-ca, zimbra-aspell-da, zimbra-aspell-de
 Requires:           zimbra-aspell-en, zimbra-aspell-es, zimbra-aspell-fr, zimbra-aspell-hi
 Requires:           zimbra-aspell-hu, zimbra-aspell-it, zimbra-aspell-nl, zimbra-aspell-pl
-Requires:           zimbra-aspell-pt-br, zimbra-aspell-ru, zimbra-aspell-sv, zimbra-httpd >= 2.4.54-1zimbra8.7b3ZAPPEND
+Requires:           zimbra-aspell-pt-br, zimbra-aspell-ru, zimbra-aspell-sv, zimbra-httpd >= 2.4.54-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-php >= 7.4.27-1zimbra8.7b3ZAPPEND, zimbra-aspell-zimbra
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
@@ -19,6 +19,8 @@ Zimbra spell components pulls in all the packages used by
 zimbra-spell
 
 %changelog
+* Wed Nov 23 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.10
+- Fix ZBUG-3126
 * Tue Oct 18 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.9
 - Fix ZBUG-2819, Upgraded Apache to 2.4.54
 * Tue Mar 15 2022 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.8


### PR DESCRIPTION
**Problem:** 
Apache is pointing to pcre2 at compilation time instead of pointing to pcre. This is happening when pcre, pcre2 are installed on build server. Apache was compiled with pcre2 but apache binary not able to find pcre2 library on installation server and this leads to apache start failed.

**Fix:**
Apache should point to pcre at compilation time.