### PR TITLE
ZCS-13150 : Update osl for ZCS 10.0.0

### DIFF
--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (4.0.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * Updated osl package, Update modern UI, 3rd party open source licenses
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 29 Mar 2023 00:00:00 +0000
+
 zimbra-core-components (3.0.18-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-3278, Upgraded OpenSSL to 1.1.1t

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -13,7 +13,7 @@ Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-rsync,
  zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-prepflog,
  zimbra-tcmalloc-lib, zimbra-perl-innotop (>= 1.9.1-1zimbra8.7b3ZAPPEND), zimbra-openjdk (>= 17.0.2-1zimbra8.8b1ZAPPEND),
- zimbra-openjdk-cacerts (>= 1.0.8-1zimbra8.7b1ZAPPEND), zimbra-osl (>= 2.0.0-1zimbra9.0b1ZAPPEND), zimbra-amavis-logwatch,
+ zimbra-openjdk-cacerts (>= 1.0.8-1zimbra8.7b1ZAPPEND), zimbra-osl (>= 3.0.0-1zimbra10.0b1ZAPPEND), zimbra-amavis-logwatch,
  zimbra-postfix-logwatch (>= 1.40.03-1zimbra8.7b1ZAPPEND), zimbra-rrdtool
 Description: Zimbra components for core package
  Zimbra core components pulls in all the packages used by

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            3.0.18
-Release:            1zimbra8.8b1ZAPPEND
+Version:            4.0.0
+Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-base, zimbra-os-requirements >= 1.0.2-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.7-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-pflogsumm
@@ -9,7 +9,7 @@ Requires:           zimbra-openssl >= 1.1.1t-1zimbra8.7b4ZAPPEND,zimbra-curl >= 
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-rsync
 Requires:           zimbra-mariadb-libs >= 10.1.25-1zimbra8.7b3ZAPPEND, zimbra-openldap-client >= 2.4.59-1zimbra8.8b5ZAPPEND
-Requires:           zimbra-osl >= 2.0.0-1zimbra9.0b1ZAPPEND
+Requires:           zimbra-osl >= 3.0.0-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-prepflog, zimbra-tcmalloc-libs, zimbra-perl-innotop >= 1.9.1-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-openjdk >= 17.0.2-1zimbra8.8b1ZAPPEND, zimbra-openjdk-cacerts >= 1.0.8-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-amavis-logwatch
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Wed Mar 29 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 4.0.0
+- Updated osl package, Update modern UI, 3rd party open source licenses
 * Fri Feb 10 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.18
 - Fix ZBUG-3278, upgraded OpenSSL to 1.1.1t and updated core-components to 3.0.18
 * Tue Feb 07 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.17

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (3.0.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * Updated core-components,osl package, Update modern UI, 3rd party open source licenses
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 29 Mar 2023 00:00:00 +0000
+
 zimbra-ldap-components (2.0.12-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * Fix ZBUG-3278, upgraded OpenSSL to 1.1.1t and updated core-components to 3.0.18

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openldap-server (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openssl (>= 1.1.1t-1zimbra8.7b4ZAPPEND), zimbra-openssl-lib (>= 1.1.1t-1zimbra8.7b4ZAPPEND), zimbra-core-components (>= 3.0.18-1zimbra8.8b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openldap-server (>= 2.4.59-1zimbra8.8b5ZAPPEND), zimbra-openssl (>= 1.1.1t-1zimbra8.7b4ZAPPEND), zimbra-openssl-lib (>= 1.1.1t-1zimbra8.7b4ZAPPEND), zimbra-core-components (>= 4.0.0-1zimbra10.0b1ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            2.0.12
-Release:            ITERATIONZAPPEND
+Version:            3.0.0
+Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.4.59-1zimbra8.8b5ZAPPEND
 Requires:           zimbra-openldap-server >= 2.4.59-1zimbra8.8b5ZAPPEND
 Requires:           zimbra-openssl >= 1.1.1t-1zimbra8.7b4ZAPPEND, zimbra-openssl-libs >= 1.1.1t-1zimbra8.7b4ZAPPEND
-Requires:           zimbra-core-components >= 3.0.18-1zimbra8.8b1ZAPPEND
+Requires:           zimbra-core-components >= 4.0.0-1zimbra10.0b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -18,6 +18,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Wed Mar 29 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.0
+- Updated core-components,osl package, Update modern UI, 3rd party open source licenses
 * Fri Feb 10 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.12
 - Fix ZBUG-3278, upgraded OpenSSL to 1.1.1t and updated core-components to 3.0.18
 * Tue Feb 07 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.11

--- a/zimbra/osl/zimbra-osl/debian/changelog
+++ b/zimbra/osl/zimbra-osl/debian/changelog
@@ -1,3 +1,8 @@
+zimbra-osl (3.0.0-1zimbra10.0b1ZAPPEND) unstable; urgency=low
+  * Update modern UI, 3rd party open source licenses
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 29 Mar 2023 00:00:00 +0000
+
 zimbra-osl (2.0.0-1zimbra9.0b1ZAPPEND) unstable; urgency=low
   * Update modern webclient
 

--- a/zimbra/osl/zimbra-osl/rpm/SPECS/osl.spec
+++ b/zimbra/osl/zimbra-osl/rpm/SPECS/osl.spec
@@ -1,7 +1,7 @@
 Summary:            Opensource Licenses
 Name:               zimbra-osl
-Version:            2.0.0
-Release:            1zimbra9.0b1ZAPPEND
+Version:            3.0.0
+Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-base
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
@@ -15,6 +15,8 @@ This file contains the licenses for the open source 3rd party
 software used by Zimbra
 
 %changelog
+* Wed Mar 29 2023  Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.0-1zimbra10.0b1ZAPPEND
+- Update modern UI, 3rd party open source licenses
 * Tue Mar 31 2020  Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.0-1zimbra9.0b1ZAPPEND
 - Update modern UI
 * Thu Jun 30 2016  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.9-ITERATIONZAPPEND


### PR DESCRIPTION
We have updated Modern UI, 3rd party open source licenses. 

-  licenses changes will be part of `zimbra-osl` package, so updated the `zimbra-osl`
- `zimbra-core-components` depends on `zimbra-osl`, so updated the `zimbra-core-components`
- `zimbra-ldap-components` depends on `zimbra-core-components`, so updated the `zimbra-ldap-components`

Below packages are updated

- zimbra-osl : 3.0.0-1zimbra10.0b1
- zimbra-core-components : 4.0.0-1zimbra10.0b1
- zimbra-ldap-components : 3.0.0-1zimbra10.0b1