### PR TITLE
ZCS-13436 : Fix Blocking domain still delivers mail

### DIFF
--- a/thirdparty/amavisd/patches/amavisd.patch
+++ b/thirdparty/amavisd/patches/amavisd.patch
@@ -9,19 +9,6 @@ diff -ruN a/bin/amavisd b/bin/amavisd
  
  #------------------------------------------------------------------------------
  # This is amavis.
-diff -ruN a/bin/amavisd-signer b/bin/amavisd-signer
---- a/bin/amavisd-signer	2023-03-10 14:10:56.003506111 +0000
-+++ b/bin/amavisd-signer	2023-03-10 14:16:18.491679909 +0000
-@@ -492,6 +492,9 @@
-     my(@dkeys); my($d) = $domain;
-     for (;;) {               # (@).sub.example.com (@).example.com (@).com (@).
-       push(@dkeys, $prepend_to_domain.'.'.$d);
-+      if ($d ne '') {
-+        push(@dkeys, $d);
-+      }
-       last  if $d eq '';
-       $d = ($d =~ /^([^.]*)\.(.*)\z/s) ? $2 : '';
-     }
 diff -ruN a/lib/Amavis/Unpackers.pm b/lib/Amavis/Unpackers.pm
 --- a/lib/Amavis/Unpackers.pm	2023-03-10 14:27:33.080974132 +0000
 +++ b/lib/Amavis/Unpackers.pm	2023-03-10 14:28:18.508404230 +0000

--- a/thirdparty/amavisd/patches/rfc2821_2822_Tools.patch
+++ b/thirdparty/amavisd/patches/rfc2821_2822_Tools.patch
@@ -1,0 +1,13 @@
+diff -ruN a/lib/Amavis/rfc2821_2822_Tools.pm b/lib/Amavis/rfc2821_2822_Tools.pm
+--- a/lib/Amavis/rfc2821_2822_Tools.pm	2023-05-19 17:30:55.604045794 +0000
++++ b/lib/Amavis/rfc2821_2822_Tools.pm	2023-05-19 17:32:29.812090542 +0000
+@@ -515,6 +515,9 @@
+     my(@dkeys); my $d = $domain;
+     for (;;) {            # (@).sub.example.com (@).example.com (@).com (@).
+       push(@dkeys, $prepend_to_domain.'.'.$d);
++      if ($d ne '') {
++	push(@dkeys, $d);
++      }
+       last  if $d eq '';
+       $d = ($d =~ /^([^.]*)\.(.*)\z/s) ? $2 : '';
+     }

--- a/thirdparty/amavisd/zimbra-amavisd/debian/patches/series
+++ b/thirdparty/amavisd/zimbra-amavisd/debian/patches/series
@@ -4,3 +4,4 @@ perl-path.patch
 socketpath.patch
 zmq-sock.patch
 amavis-pm.patch
+rfc2821_2822_Tools.patch

--- a/thirdparty/amavisd/zimbra-amavisd/rpm/SPECS/amavisd.spec
+++ b/thirdparty/amavisd/zimbra-amavisd/rpm/SPECS/amavisd.spec
@@ -10,6 +10,7 @@ Patch2:             perl-path.patch
 Patch3:             socketpath.patch
 Patch4:             zmq-sock.patch
 Patch5:             amavis-pm.patch
+Patch6:             rfc2821_2822_Tools.patch
 Requires:           perl, zimbra-mta-base
 AutoReqProv:        no
 URL:                https://gitlab.com/amavis/amavis
@@ -27,6 +28,7 @@ The Zimbra amavisd build
 %patch3 -p1
 %patch4 -p1
 %patch5 -p1
+%patch6 -p1
 
 %build
 


### PR DESCRIPTION
**Problem:** Blocking domain still delivers mail.

1. Login to xyz@testdomain.com
2. Go to preferences -> Block particular domain ( test.com )-> Logout
3. Login to blocked domain account (abc@test.com)
4. Send mail to xyz@testdomain.com

Mail is delivered fine to xyz@testdomain.com which is wrong considering domain is blocked.

**Logs:**

**amavis-2.10.1:**
amavis[463502]: (463502-03) wbl: checking sender <abc@test.com>
amavis[463502]: (463502-03) query_keys: abc@test.com, @test.com, @.test.com, test.com, @.com, com, @.
amavis[463502]: (463502-03) wbl: (LDAP) query keys: "abc@test.com", "@test.com", "@.test.com", "test.com", "@.com", "com", "@."
amavis[463502]: (463502-03) lookup_ldap_attr(amavisBlacklistSender) rec=0, "xyz@testdomain.com" result: "ARRAY(0x55a5dea36a78)"
amavis[463502]: (463502-03) wbl: (LDAP) recip <xyz@testdomain.com> blacklisted sender <abc@test.com>
amavis[463502]: (463502-03) query_keys: abc@test.com, abc@, test.com, .test.com, .com, com, .
amavis[463502]: (463502-03) wbl: blacklisted sender <abc@test.com>

**amavis-2.13.0:**
amavis[445763]: (445763-05) wbl: checking sender <abc@test.com>
amavis[445763]: (445763-05) query_keys: abc@test.com, @test.com, @.test.com, @.com, @.
amavis[445763]: (445763-05) wbl: (LDAP) query keys: "abc@test.com", "@test.com", "@.test.com", "@.com", "@."
amavis[445763]: (445763-05) lookup_ldap_attr(amavisBlacklistSender) rec=0, "xyz@testdomain.com" result: "ARRAY(0x5614b07ac990)"

`test.com , com ` are missing for amavis-2.13.0 in query_keys, due to this amavis-2.13.0 sending message as `Passed CLEAN` and amavis-2.10.1 treating message as `Blocked SPAM`.

**Fix:**

We have a patch in amavisd file for this issue. (https://github.com/Zimbra/packages/blob/9.0.0.p31/thirdparty/amavisd/patches/amavisd.patch#L16). But in amavis-2.13.0 patch related code block has been moved to new file rfc2821_2822_Tools.pm (https://gitlab.com/amavis/amavis/-/blob/2.13-stable/lib/Amavis/rfc2821_2822_Tools.pm), so to fix this we need to apply same patch in rfc2821_2822_Tools.pm file. Similar code block is present in the file bin/amavisd-signer, removing this as we are not using it.
