### PR TITLE
ZBUG-2931 : added rsyslog, libcap, net-tools in os-requirements

### DIFF
--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (4.0.1-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-2931, Updated os-requirements
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 17 Jul 2023 00:00:00 +0000
+
 zimbra-core-components (4.0.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * ZBUG-3355, Updated OpenSSL License and other 3rd party open source licenses

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-core-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-base, zimbra-os-requirements (>= 1.0.2-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.8-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
+ zimbra-base, zimbra-os-requirements (>= 1.0.3-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.8-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
  zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-curl (>= 7.49.1-1zimbra8.7b4ZAPPEND), zimbra-cyrus-sasl (>= 2.1.28-1zimbra8.7b4ZAPPEND),
  zimbra-rsync,
  zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.4.59-1zimbra8.8b6ZAPPEND), zimbra-prepflog,

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            4.0.0
+Version:            4.0.1
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-base, zimbra-os-requirements >= 1.0.2-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.8-1zimbra8.7b1ZAPPEND
+Requires:           zimbra-base, zimbra-os-requirements >= 1.0.3-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.8-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-pflogsumm
 Requires:           zimbra-openssl >= 3.0.9-1zimbra8.8b1ZAPPEND,zimbra-curl >= 7.49.1-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b4ZAPPEND
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Mon Jul 17 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 4.0.1
+- ZBUG-2931, Updated os-requirements
 * Fri Jul 07 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 4.0.0
 - ZBUG-3355, Updated OpenSSL License and other 3rd party open source licenses
 * Tue Jun 13 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.19

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (3.0.1-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-2931, Updated core-requirements, os-requirements
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 17 Jul 2023 00:00:00 +0000
+
 zimbra-ldap-components (3.0.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * ZBUG-3355, Updated core-components, OpenSSL License and other 3rd party open source licenses

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.4.59-1zimbra8.8b6ZAPPEND), zimbra-openldap-server (>= 2.4.59-1zimbra8.8b6ZAPPEND), zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 4.0.0-1zimbra10.0b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.4.59-1zimbra8.8b6ZAPPEND), zimbra-openldap-server (>= 2.4.59-1zimbra8.8b6ZAPPEND), zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 4.0.1-1zimbra10.0b1ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            3.0.0
+Version:            3.0.1
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.4.59-1zimbra8.8b6ZAPPEND
 Requires:           zimbra-openldap-server >= 2.4.59-1zimbra8.8b6ZAPPEND
 Requires:           zimbra-openssl >= 3.0.9-1zimbra8.8b1ZAPPEND, zimbra-openssl-libs >= 3.0.9-1zimbra8.8b1ZAPPEND
-Requires:           zimbra-core-components >= 4.0.0-1zimbra10.0b1ZAPPEND
+Requires:           zimbra-core-components >= 4.0.1-1zimbra10.0b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -18,6 +18,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Mon Jul 17 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.1
+- ZBUG-2931, Updated core-requirements, os-requirements
 * Fri Jul 07 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.0
 - ZBUG-3355, Updated core-components, OpenSSL License and other 3rd party open source licenses
 * Tue Jun 13 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - 2.0.13

--- a/zimbra/os-requirements/zimbra-os-requirements/debian/changelog
+++ b/zimbra/os-requirements/zimbra-os-requirements/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-os-requirements (1.0.3-1zimbra8.7b1ZAPPEND) unstable; urgency=low
+
+  * ZBUG-2931, added rsyslog, net-tools, libcap2-bin in os-requirements
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 17 Jul 2023 00:00:00 +0000
+
 zimbra-os-requirements (1.0.2-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * Fix ZBUG-3017

--- a/zimbra/os-requirements/zimbra-os-requirements/debian/control
+++ b/zimbra/os-requirements/zimbra-os-requirements/debian/control
@@ -10,7 +10,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  coreutils, file, libaio1, libexpat1, libidn11, libpcre3, libstdc++6,
  lsb-release, netcat-openbsd, pax, perl, procps, resolvconf, sudo,
- sysstat, unzip, zimbra-base, libsocket6-perl,
+ sysstat, unzip, zimbra-base, libsocket6-perl, rsyslog, net-tools, libcap2-bin,
  OSDEPS
 Description: Zimbra OS Requirements
  Zimbra OS requirements is used as a simple method to pull in all

--- a/zimbra/os-requirements/zimbra-os-requirements/rpm/SPECS/os-requirements.spec
+++ b/zimbra/os-requirements/zimbra-os-requirements/rpm/SPECS/os-requirements.spec
@@ -1,13 +1,13 @@
 Summary:            Zimbra OS Requirements
 Name:               zimbra-os-requirements
-Version:            1.0.2
+Version:            1.0.3
 Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 Requires:           coreutils, expat, file, gmp, libaio, libidn, libstdc++, pcre
 Requires:           perl, perl-core, sudo, sysstat, unzip, zimbra-base
-Requires:           perl-Socket6, OSDEPS
+Requires:           perl-Socket6, rsyslog, net-tools, libcap, OSDEPS
 AutoReqProv:        no
 
 %define debug_package %{nil}
@@ -17,6 +17,8 @@ Zimbra OS requirements is used as a simple method to pull in all
 OS required core packages
 
 %changelog
+* Mon Jul 17 2023  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3-1zimbra8.7b1ZAPPEND
+- ZBUG-2931, added rsyslog, net-tools, libcap in os-requirements
 * Mon Sep 12 2022  Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b1ZAPPEND
 - Fix ZBUG-3017
 


### PR DESCRIPTION
**Problem :** rsyslog, libcap, net-tools are required and these are not installed by default in below OS

OS Version : Rocky Linux release 8.6
Setting defaults...sh: /sbin/ifconfig: No such file or directory

OS Version : 18.04.6 LTS
/opt/zimbra/libexec/zmfixperms: line 701: setcap: command not found
ERROR: No syslog configuration edited

OS Version : 20.04.6 LTS
Setting defaults...sh: 1: /sbin/ifconfig: not found
Checking for port conflicts
sh: 1: netstat: not found -> net-tools -> /bin/netstat

**Fix:**  added  rsyslog, libcap, net-tools as dependency in os-requirements to install with the ZCS build
