### PR TITLE
ZCS-12461 : Compiled postfix with EAI support

### DIFF
--- a/thirdparty/postfix/zimbra-postfix/debian/changelog
+++ b/thirdparty/postfix/zimbra-postfix/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-postfix (VERSION-1zimbra8.7b6ZAPPEND) unstable; urgency=medium
+
+  * Enable EAI support
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 13 Sep 2024 00:00:00 +0000
+
 zimbra-postfix (VERSION-1zimbra8.7b5ZAPPEND) unstable; urgency=medium
 
   * Updated postfix for openldap-2.5.17

--- a/thirdparty/postfix/zimbra-postfix/debian/control
+++ b/thirdparty/postfix/zimbra-postfix/debian/control
@@ -1,7 +1,7 @@
 Source: zimbra-postfix
 Build-Depends: debhelper (>= 9), m4, dpkg-dev (>= 1.15.7),
  zimbra-openldap-dev (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-cyrus-sasl-dev (>= 2.1.28-1zimbra8.7b4ZAPPEND), zimbra-openssl-dev (>= 3.0.9-1zimbra8.8b1ZAPPEND),
- zimbra-mariadb-dev, zimbra-lmdb-dev (>= 2.5.17-1zimbra10.0b1ZAPPEND), libpcre3-dev
+ zimbra-mariadb-dev, zimbra-lmdb-dev (>= 2.5.17-1zimbra10.0b1ZAPPEND), libpcre3-dev, libicu-dev
 Section: utils
 Priority: optional
 Maintainer: Zimbra Packaging Services <packaging-devel@zimbra.com>

--- a/thirdparty/postfix/zimbra-postfix/rpm/SPECS/postfix.spec
+++ b/thirdparty/postfix/zimbra-postfix/rpm/SPECS/postfix.spec
@@ -1,7 +1,7 @@
 Summary:            Zimbra's Postfix build
 Name:               zimbra-postfix
 Version:            VERSION
-Release:            1zimbra8.7b5ZAPPEND
+Release:            1zimbra8.7b6ZAPPEND
 License:            IPL-1.0
 Source:             %{name}-%{version}.tar.gz
 BuildRequires:      zimbra-openldap-devel >= 2.5.17-1zimbra10.0b1ZAPPEND
@@ -9,7 +9,7 @@ BuildRequires:      zimbra-cyrus-sasl-devel >= 2.1.28-1zimbra8.7b4ZAPPEND
 BuildRequires:      zimbra-openssl-devel >= 3.0.9-1zimbra8.8b1ZAPPEND
 BuildRequires:      zimbra-mariadb-devel
 BuildRequires:      zimbra-lmdb-devel >= 2.5.17-1zimbra10.0b1ZAPPEND
-BuildRequires:      pcre-devel
+BuildRequires:      pcre-devel, libicu-devel
 Requires:           pcre, libicu
 Requires:           zimbra-openldap-libs >= 2.5.17-1zimbra10.0b1ZAPPEND, zimbra-mta-base
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b4ZAPPEND, zimbra-mariadb
@@ -27,6 +27,8 @@ The Zimbra Postfix build
 %define debug_package %{nil}
 
 %changelog
+* Fri Sep 13 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b6ZAPPEND
+- Enable EAI support
 * Sat May 11 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b5ZAPPEND
 - Updated postfix for openldap-2.5.17
 * Fri Jan 26 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b4ZAPPEND

--- a/zimbra/mta-components/zimbra-mta-components/debian/changelog
+++ b/zimbra/mta-components/zimbra-mta-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-mta-components (1.0.26-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Enable EAI support in postfix
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 13 Sep 2024 00:00:00 +0000
+
 zimbra-mta-components (1.0.25-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * ZCS-15540, Upgraded ClamAV to 1.0.6

--- a/zimbra/mta-components/zimbra-mta-components/debian/control
+++ b/zimbra/mta-components/zimbra-mta-components/debian/control
@@ -12,7 +12,7 @@ Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-clamav (>= 1.0.6-1zimbra8.8b4ZAPPEND),
  zimbra-clamav-db (>= 1.0.0-1zimbra8.7b2ZAPPEND), zimbra-cluebringer, zimbra-mariadb (>= 10.1.25-1zimbra8.7b3ZAPPEND),
  zimbra-opendkim (>= 2.10.3-1zimbra8.7b7ZAPPEND), zimbra-perl-mail-spamassassin (>= 3.4.6-1zimbra8.8b4ZAPPEND),
- zimbra-postfix (>= 3.6.14-1zimbra8.7b5ZAPPEND),
+ zimbra-postfix (>= 3.6.14-1zimbra8.7b6ZAPPEND),
  zimbra-spamassassin-rules (>= 1.0.0-1zimbra8.8b6ZAPPEND)
 Description: Zimbra components for MTA package
  Zimbra mta components pulls in all the packages used by

--- a/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
+++ b/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
@@ -1,13 +1,13 @@
 Summary:            Zimbra components for MTA package
 Name:               zimbra-mta-components
-Version:            1.0.25
+Version:            1.0.26
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
 Requires:           sqlite, zimbra-mta-base, zimbra-altermime, zimbra-amavisd >= 2.13.0-1zimbra8.7b2ZAPPEND
 Requires:           zimbra-clamav >= 1.0.6-1zimbra8.8b4ZAPPEND, zimbra-clamav-db >= 1.0.0-1zimbra8.7b2ZAPPEND
 Requires:           zimbra-cluebringer, zimbra-mariadb >= 10.1.25-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-opendkim >= 2.10.3-1zimbra8.7b7ZAPPEND, zimbra-perl-mail-spamassassin >= 3.4.6-1zimbra8.8b4ZAPPEND
-Requires:           zimbra-postfix >= 3.6.14-1zimbra8.7b5ZAPPEND
+Requires:           zimbra-postfix >= 3.6.14-1zimbra8.7b6ZAPPEND
 Requires:           zimbra-spamassassin-rules >= 1.0.0-1zimbra8.8b6ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
@@ -20,6 +20,8 @@ Zimbra mta components pulls in all the packages used by
 zimbra-mta
 
 %changelog
+* Fri Sep 13 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.26
+- Enable EAI support in postfix
 * Mon Jul 29 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.25
 - ZCS-15540, Upgraded ClamAV to 1.0.6
 * Sat May 11 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.24


### PR DESCRIPTION
https://github.com/Zimbra/zm-mailbox/pull/1658
https://github.com/Zimbra/zm-ldap-utilities/pull/18

```
$ postconf -e smtputf8_enable=yes

$ postfix reload
postalias: warning: smtputf8_enable is true, but EAI support is not compiled in
postfix: warning: smtputf8_enable is true, but EAI support is not compiled in
postfix/postlog: warning: smtputf8_enable is true, but EAI support is not compiled in
/postfix-script: refreshing the Postfix mail system
postsuper: warning: smtputf8_enable is true, but EAI support is not compiled in
postsuper: warning: smtputf8_enable is true, but EAI support is not compiled in
```

This PR enables SMTPUTF8 support in Postfix. However, it requires changes in other components such as LDAP, LMTP, Mailbox, and Web Client UI.

Before Fix:
```
telnet localhost 25
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
220 localhost ESMTP Postfix
ehlo localhost
250-localhost
250-PIPELINING
250-SIZE 10240000
250-VRFY
250-ETRN
250-STARTTLS
250-ENHANCEDSTATUSCODES
250-8BITMIME
250 DSN
^]
```

After Fix:
The Postfix SMTP server announces SMTPUTF8 support in the EHLO response.
```
telnet localhost 25
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
220 localhost ESMTP Postfix
ehlo localhost
250-localhost
250-PIPELINING
250-SIZE 10240000
250-VRFY
250-ETRN
250-STARTTLS
250-ENHANCEDSTATUSCODES
250-8BITMIME
250-DSN
250 SMTPUTF8
^]
```