### PR TITLE
ZCS-15997 : Bumped-up core, ldap, mta components versions for ZCS-10.1.0

### DIFF
--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (10.1.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * Bumped-up version to differentiate from ZCS 10
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Jul 2024 00:00:00 +0000
+
 zimbra-core-components (4.0.4-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * Upgrade Openjdk to 17.0.12

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,6 +1,6 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            4.0.4
+Version:            10.1.0
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-base, zimbra-os-requirements >= 1.0.3-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.9-1zimbra8.7b1ZAPPEND
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.0
+- Bumped-up version to differentiate from ZCS 10
 * Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 4.0.4
 - Upgrade Openjdk to 17.0.12
 * Mon Mar 04 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 4.0.3

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (10.1.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * Bumped-up version to differentiate from ZCS 10
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 22 Jul 2024 00:00:00 +0000
+
 zimbra-ldap-components (3.0.4-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * Upgrade Openjdk to 17.0.12, Updated core-components for openjdk

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openldap-server (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 4.0.4-1zimbra10.0b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openldap-server (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 10.1.0-1zimbra10.0b1ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            3.0.4
+Version:            10.1.0
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.5.17-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-openldap-server >= 2.5.17-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-openssl >= 3.0.9-1zimbra8.8b1ZAPPEND, zimbra-openssl-libs >= 3.0.9-1zimbra8.8b1ZAPPEND
-Requires:           zimbra-core-components >= 4.0.4-1zimbra10.0b1ZAPPEND
+Requires:           zimbra-core-components >= 10.1.0-1zimbra10.0b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -18,6 +18,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.0
+- Bumped-up version to differentiate from ZCS 10
 * Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.4
 - Upgrade Openjdk to 17.0.12, Updated core-components for openjdk
 * Mon Mar 04 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.3

--- a/zimbra/mta-components/zimbra-mta-components/debian/changelog
+++ b/zimbra/mta-components/zimbra-mta-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-mta-components (10.1.0-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * Bumped-up version to differentiate from ZCS 10
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 29 Jul 2024 00:00:00 +0000
+
 zimbra-mta-components (1.0.25-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * ZCS-15540, Upgraded ClamAV to 1.0.6

--- a/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
+++ b/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
@@ -1,6 +1,6 @@
 Summary:            Zimbra components for MTA package
 Name:               zimbra-mta-components
-Version:            1.0.25
+Version:            10.1.0
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
 Requires:           sqlite, zimbra-mta-base, zimbra-altermime, zimbra-amavisd >= 2.13.0-1zimbra8.7b2ZAPPEND
@@ -20,6 +20,8 @@ Zimbra mta components pulls in all the packages used by
 zimbra-mta
 
 %changelog
+* Mon Jul 29 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.0
+- Bumped-up version to differentiate from ZCS 10
 * Mon Jul 29 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.25
 - ZCS-15540, Upgraded ClamAV to 1.0.6
 * Sat May 11 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.24


### PR DESCRIPTION
Updated versions of the core, LDAP, and MTA components for ZCS 10.1.0. Until the OpenLDAP upgrade, the packages for both ZCS 10.0.0 and 10.1.0 remain the same. However, we did not release an OpenLDAP upgrade or its dependent packages (core, LDAP, MTA components) for ZCS 10.0.0. To facilitate the release of ClamAV and OpenJDK upgrades for ZCS 10 and 10.1, we need to create separate packages for the core, LDAP, and MTA components.