### PR TITLE
ZBUG-4617: removed rsyslog from os-requirements

### DIFF
--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (10.1.2-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-4617, Updated os-requirements(removed rsyslog dependency)
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Thu, 08 May 2025 00:00:00 +0000
+
 zimbra-core-components (10.1.1-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * ZBUG-3966, Updated os-requirements

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-core-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-base, zimbra-os-requirements (>= 1.0.4-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.9-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
+ zimbra-base, zimbra-os-requirements (>= 1.0.5-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.9-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
  zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-curl (>= 7.49.1-1zimbra8.7b4ZAPPEND), zimbra-cyrus-sasl (>= 2.1.28-1zimbra8.7b4ZAPPEND),
  zimbra-rsync,
  zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-prepflog,

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,9 +1,9 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            10.1.1
+Version:            10.1.2
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-base, zimbra-os-requirements >= 1.0.4-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.9-1zimbra8.7b1ZAPPEND
+Requires:           zimbra-base, zimbra-os-requirements >= 1.0.5-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.9-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-pflogsumm
 Requires:           zimbra-openssl >= 3.0.9-1zimbra8.8b1ZAPPEND,zimbra-curl >= 7.49.1-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b4ZAPPEND
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Thu May 08 2025  Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.2
+- ZBUG-4617, Updated os-requirements(removed rsyslog dependency)
 * Wed May 07 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.1
 - ZBUG-3966, Updated os-requirements
 * Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.0

--- a/zimbra/os-requirements/zimbra-os-requirements/debian/changelog
+++ b/zimbra/os-requirements/zimbra-os-requirements/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-os-requirements (1.0.5-1zimbra8.7b1ZAPPEND) unstable; urgency=low
+
+  * ZBUG-4617, removed rsyslog dependency from os-requirements
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Thu, 08 May 2025 00:00:00 +0000
+
 zimbra-os-requirements (1.0.4-1zimbra8.7b1ZAPPEND) unstable; urgency=low
 
   * ZBUG-3966, added pstack, gdb, lsof, bzip2 in os-requirements

--- a/zimbra/os-requirements/zimbra-os-requirements/debian/control
+++ b/zimbra/os-requirements/zimbra-os-requirements/debian/control
@@ -10,7 +10,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  coreutils, file, libaio1, libexpat1, libidn11, libpcre3, libstdc++6,
  lsb-release, netcat-openbsd, pax, perl, procps, resolvconf, sudo,
- sysstat, unzip, zimbra-base, libsocket6-perl, rsyslog, net-tools, libcap2-bin, pstack, gdb, lsof, bzip2,
+ sysstat, unzip, zimbra-base, libsocket6-perl, net-tools, libcap2-bin, pstack, gdb, lsof, bzip2,
  OSDEPS
 Description: Zimbra OS Requirements
  Zimbra OS requirements is used as a simple method to pull in all

--- a/zimbra/os-requirements/zimbra-os-requirements/rpm/SPECS/os-requirements.spec
+++ b/zimbra/os-requirements/zimbra-os-requirements/rpm/SPECS/os-requirements.spec
@@ -1,13 +1,13 @@
 Summary:            Zimbra OS Requirements
 Name:               zimbra-os-requirements
-Version:            1.0.4
+Version:            1.0.5
 Release:            1zimbra8.7b1ZAPPEND
 License:            GPL-2
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 Requires:           coreutils, expat, file, gmp, libaio, libidn, libstdc++, pcre
 Requires:           perl, perl-core, sudo, sysstat, unzip, zimbra-base
-Requires:           perl-Socket6, rsyslog, net-tools, libcap
+Requires:           perl-Socket6, net-tools, libcap
 Requires:           gdb, lsof, bzip2, OSDEPS 
 AutoReqProv:        no
 
@@ -18,6 +18,8 @@ Zimbra OS requirements is used as a simple method to pull in all
 OS required core packages
 
 %changelog
+* Thu May 08 2025  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.5-1zimbra8.7b1ZAPPEND
+- ZBUG-4617, removed rsyslog dependency from os-requirements
 * Thu Apr 25 2025  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.4-1zimbra8.7b1ZAPPEND
 - ZBUG-3966, added gdb, lsof, bzip2 in os-requirements
 * Mon Jul 17 2023  Zimbra Packaging Services <packaging-devel@zimbra.com> - 1.0.3-1zimbra8.7b1ZAPPEND


### PR DESCRIPTION
Removed rsyslog package dependency from os-requirement as part of https://synacor.atlassian.net/browse/ZBUG-4617 Fix
because rsyslog package attempts to remove **zimbra-packages** & other **zimbra-dependencies** ..