### PR TITLE
ZBUG-5062:Added missing dependencies for rsync

### DIFF
--- a/thirdparty/rsync/zimbra-rsync/debian/changelog
+++ b/thirdparty/rsync/zimbra-rsync/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-rsync (VERSION-1zimbra8.7b2ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-5062, Bumped-up rsync version due to addition of missing dependencies
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 06 Aug 2025 13:26:24 +0000
+
 zimbra-rsync (VERSION-1zimbra8.7b1ZAPPEND) unstable; urgency=medium
 
   * ZBUG-4670, Upgraded rsync to 3.4.1

--- a/thirdparty/rsync/zimbra-rsync/debian/control
+++ b/thirdparty/rsync/zimbra-rsync/debian/control
@@ -1,5 +1,5 @@
 Source: zimbra-rsync
-Build-Depends: debhelper (>= 9), m4, dpkg-dev (>= 1.15.7), libpopt-dev
+Build-Depends: debhelper (>= 9), m4, dpkg-dev (>= 1.15.7), libpopt-dev, libxxhash-dev, libzstd-dev
 Section: utils
 Priority: optional
 Maintainer: Zimbra Packaging Services <packaging-devel@zimbra.com>
@@ -10,7 +10,7 @@ Homepage:  https://rsync.samba.org
 Package: zimbra-rsync
 Priority: optional
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, zimbra-base, libxxhash-dev, libzstd-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, zimbra-base
 Description: rsync Binaries
 
 Package: zimbra-rsync-dbg

--- a/thirdparty/rsync/zimbra-rsync/debian/control
+++ b/thirdparty/rsync/zimbra-rsync/debian/control
@@ -10,7 +10,7 @@ Homepage:  https://rsync.samba.org
 Package: zimbra-rsync
 Priority: optional
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, zimbra-base
+Depends: ${shlibs:Depends}, ${misc:Depends}, zimbra-base, libxxhash-dev, libzstd-dev
 Description: rsync Binaries
 
 Package: zimbra-rsync-dbg

--- a/thirdparty/rsync/zimbra-rsync/rpm/SPECS/rsync.spec
+++ b/thirdparty/rsync/zimbra-rsync/rpm/SPECS/rsync.spec
@@ -1,11 +1,11 @@
 Summary:            Zimbra's rsync build
 Name:               zimbra-rsync
 Version:            3.4.1
-Release:            1zimbra8.7b1ZAPPEND
+Release:            1zimbra8.7b2ZAPPEND
 License:            GPL-3
 Source:             %{name}-%{version}.tar.gz
-BuildRequires:      popt-devel
-Requires:           popt, zimbra-base
+BuildRequires:      popt-devel, xxhash-devel
+Requires:           popt, zimbra-base, xxhash-libs
 AutoReqProv:        no
 URL:                https://rsync.samba.org
 
@@ -31,5 +31,7 @@ OZCB
 OZCS
 
 %changelog
+* Wed Aug 06 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b2ZAPPEND
+- ZBUG-5062, Bumped-up rsync version due to addition of missing dependencies
 * Wed Feb 05 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b1ZAPPEND
 - ZBUG-4670, Upgraded rsync to 3.4.1

--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (10.1.4-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-5062, Bumped-up rsync version
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Wed, 06 Aug 2025 00:00:00 +0000
+
 zimbra-core-components (10.1.3-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * ZBUG-4670, Upgraded rsync to 3.4.1

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -10,7 +10,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-base, zimbra-os-requirements (>= 1.0.5-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.9-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
  zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-curl (>= 7.49.1-1zimbra8.7b4ZAPPEND), zimbra-cyrus-sasl (>= 2.1.28-1zimbra8.7b4ZAPPEND),
- zimbra-rsync (>= 3.4.1-1zimbra8.7b1ZAPPEND),
+ zimbra-rsync (>= 3.4.1-1zimbra8.7b2ZAPPEND),
  zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-prepflog,
  zimbra-tcmalloc-lib, zimbra-perl-innotop (>= 1.9.1-1zimbra8.7b4ZAPPEND), zimbra-openjdk (>= 17.0.12-1zimbra8.8b1ZAPPEND),
  zimbra-openjdk-cacerts (>= 1.0.11-1zimbra8.7b1ZAPPEND), zimbra-osl (>= 3.0.0-1zimbra10.0b1ZAPPEND), zimbra-amavis-logwatch,

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,13 +1,13 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            10.1.3
+Version:            10.1.4
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-base, zimbra-os-requirements >= 1.0.5-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.9-1zimbra8.7b1ZAPPEND
 Requires:           zimbra-pflogsumm
 Requires:           zimbra-openssl >= 3.0.9-1zimbra8.8b1ZAPPEND,zimbra-curl >= 7.49.1-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b4ZAPPEND
-Requires:           zimbra-rsync >= 3.4.1-1zimbra8.7b1ZAPPEND
+Requires:           zimbra-rsync >= 3.4.1-1zimbra8.7b2ZAPPEND
 Requires:           zimbra-mariadb-libs >= 10.1.25-1zimbra8.7b3ZAPPEND, zimbra-openldap-client >= 2.5.17-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-osl >= 3.0.0-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-prepflog, zimbra-tcmalloc-libs, zimbra-perl-innotop >= 1.9.1-1zimbra8.7b4ZAPPEND
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Wed Aug 06 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.4
+- ZBUG-5062, Bumped-up rsync version
 * Thu May 29 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.3
 - ZBUG-4670, Upgraded rsync to 3.4.1
 * Thu May 08 2025  Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.2

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (10.1.1-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * Updated core-components for rsync bumped-version
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Fri, 08 Aug 2025 00:00:00 +0000
+
 zimbra-ldap-components (10.1.0-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * Bumped-up version to differentiate from ZCS 10

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openldap-server (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 10.1.0-1zimbra10.0b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openldap-server (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openssl (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.0.9-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 10.1.4-1zimbra10.0b1ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            10.1.0
+Version:            10.1.1
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.5.17-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-openldap-server >= 2.5.17-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-openssl >= 3.0.9-1zimbra8.8b1ZAPPEND, zimbra-openssl-libs >= 3.0.9-1zimbra8.8b1ZAPPEND
-Requires:           zimbra-core-components >= 10.1.0-1zimbra10.0b1ZAPPEND
+Requires:           zimbra-core-components >= 10.1.4-1zimbra10.0b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -18,6 +18,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Fri Aug 08 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.1
+- Updated core-components for rsync bumped-version
 * Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.0
 - Bumped-up version to differentiate from ZCS 10
 * Mon Jul 22 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - 3.0.4


### PR DESCRIPTION
Fixing the dependency of xxhash-libs & xxhash-devel for RHEL & libxxhash-dev, libzstd-dev for Debian OS
although above dependency present by-default on OS, noticed that on U18 & R9 they may need to install while package compilation. so added it as Buildrequires:
so to fix it , created Bumped-up version for `zimbra-rsync` for All OS and upgraded `zimbra-core-components` packages.
