### PR TITLE
ZBUG-5376: Fix Openldap password/sha2 produces incorrect SHA256

### DIFF
--- a/thirdparty/openldap/patches/sha2-strict-aliasing-fix.patch
+++ b/thirdparty/openldap/patches/sha2-strict-aliasing-fix.patch
@@ -1,0 +1,12 @@
+diff -ruN a/contrib/slapd-modules/passwd/sha2/Makefile b/contrib/slapd-modules/passwd/sha2/Makefile
+--- a/contrib/slapd-modules/passwd/sha2/Makefile	2026-02-11 07:02:26.788609752 +0000
++++ b/contrib/slapd-modules/passwd/sha2/Makefile	2026-04-06 07:13:06.396367937 +0000
+@@ -9,7 +9,7 @@
+ LIBTOOL = $(LDAP_BUILD)/libtool
+ INSTALL = /usr/bin/install
+ CC = gcc
+-OPT = -g -O2
++OPT = -g -O2 -fno-strict-aliasing
+ DEFS = 
+ #DEFS = -DSLAPD_SHA2_DEBUG
+ INCS = $(LDAP_INC)

--- a/thirdparty/openldap/zimbra-openldap/debian/changelog
+++ b/thirdparty/openldap/zimbra-openldap/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-openldap (VERSION-1zimbra10.0b2ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-5376, Fix incorrect SHA256/SSHA256 hashing caused by strict aliasing optimization in GCC
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 06 Apr 2026 00:00:00 +0000
+
 zimbra-openldap (VERSION-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * Upgraded openldap to 2.5.17

--- a/thirdparty/openldap/zimbra-openldap/debian/patches/series
+++ b/thirdparty/openldap/zimbra-openldap/debian/patches/series
@@ -1,2 +1,3 @@
 liblmdb-soname.patch
 liblmdb-keysize.patch
+sha2-strict-aliasing-fix.patch

--- a/thirdparty/openldap/zimbra-openldap/debian/zimbra-lmdb-lib.shlibs
+++ b/thirdparty/openldap/zimbra-openldap/debian/zimbra-lmdb-lib.shlibs
@@ -1,1 +1,1 @@
-liblmdb 0 zimbra-lmdb-lib (>= VERSION-ITERATION)
+liblmdb 0 zimbra-lmdb-lib (>= VERSION-1zimbra10.0b2ZAPPEND)

--- a/thirdparty/openldap/zimbra-openldap/rpm/SPECS/openldap.spec
+++ b/thirdparty/openldap/zimbra-openldap/rpm/SPECS/openldap.spec
@@ -1,11 +1,12 @@
 Summary:            Zimbra's openldap build
 Name:               zimbra-openldap
 Version:            VERSION
-Release:            1zimbra10.0b1ZAPPEND
+Release:            1zimbra10.0b2ZAPPEND
 License:            BSD
 Source:             %{name}-%{version}.tgz
 Patch0:             liblmdb-soname.patch
 Patch1:             liblmdb-keysize.patch
+Patch2:             sha2-strict-aliasing-fix.patch
 BuildRequires:      zimbra-openssl-devel >= 3.0.9-1zimbra8.8b1ZAPPEND
 BuildRequires:      zimbra-cyrus-sasl-devel >= 2.1.28-1zimbra8.7b4ZAPPEND
 BuildRequires:      zimbra-libltdl-devel, zimbra-curl-devel, zimbra-heimdal-devel, zimbra-libxml2-devel
@@ -19,6 +20,8 @@ The Zimbra openldap build
 %define debug_package %{nil}
 
 %changelog
+* Mon Apr 06 2026 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra10.0b2ZAPPEND
+- ZBUG-5376, Fix incorrect SHA256/SSHA256 hashing caused by strict aliasing optimization in GCC
 * Mon Mar 04 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra10.0b1ZAPPEND
 - Upgraded openldap to 2.5.17
 * Mon Jun 12 2023 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.8b6ZAPPEND
@@ -38,6 +41,7 @@ The Zimbra openldap build
 %setup -n openldap-%{version}
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 %build
 # Alternate Makeargs: DEFINES="-DCHECK_CSN -DSLAP_SCHEMA_EXPOSE -DMDB_DEBUG=3"

--- a/thirdparty/postfix/Makefile
+++ b/thirdparty/postfix/Makefile
@@ -6,7 +6,7 @@ pvers := $(POSTFIX_VERSION)
 pname := postfix
 pfile := $(pname)-$(pvers).tar.gz
 psrc_file := $(SRC_DIR)/$(pfile)
-purl := ftp://mirrors.loonybin.net/pub/postfix/official/$(pfile)
+purl := https://postfix.cs.utah.edu/source/official/$(pfile)
 zname := zimbra-$(pname)
 zspec := $(pname).spec
 

--- a/thirdparty/postfix/zimbra-postfix/debian/changelog
+++ b/thirdparty/postfix/zimbra-postfix/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-postfix (VERSION-1zimbra8.7b7ZAPPEND) unstable; urgency=medium
+
+  * Updated openldap for ZBUG-5376
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 06 Apr 2026 00:00:00 +0000
+
 zimbra-postfix (VERSION-1zimbra8.7b6ZAPPEND) unstable; urgency=medium
 
   * ZCS-17413, Upgraded OpenSSL to 3.5.1

--- a/thirdparty/postfix/zimbra-postfix/debian/control
+++ b/thirdparty/postfix/zimbra-postfix/debian/control
@@ -1,7 +1,7 @@
 Source: zimbra-postfix
 Build-Depends: debhelper (>= 9), m4, dpkg-dev (>= 1.15.7),
- zimbra-openldap-dev (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-cyrus-sasl-dev (>= 2.1.28-1zimbra8.7b4ZAPPEND), zimbra-openssl-dev (>= 3.5.1-1zimbra8.8b1ZAPPEND),
- zimbra-mariadb-dev, zimbra-lmdb-dev (>= 2.5.17-1zimbra10.0b1ZAPPEND), libpcre3-dev
+ zimbra-openldap-dev (>= 2.5.17-1zimbra10.0b2ZAPPEND), zimbra-cyrus-sasl-dev (>= 2.1.28-1zimbra8.7b4ZAPPEND), zimbra-openssl-dev (>= 3.5.1-1zimbra8.8b1ZAPPEND),
+ zimbra-mariadb-dev, zimbra-lmdb-dev (>= 2.5.17-1zimbra10.0b2ZAPPEND), libpcre3-dev
 Section: utils
 Priority: optional
 Maintainer: Zimbra Packaging Services <packaging-devel@zimbra.com>

--- a/thirdparty/postfix/zimbra-postfix/rpm/SPECS/postfix.spec
+++ b/thirdparty/postfix/zimbra-postfix/rpm/SPECS/postfix.spec
@@ -1,19 +1,19 @@
 Summary:            Zimbra's Postfix build
 Name:               zimbra-postfix
 Version:            VERSION
-Release:            1zimbra8.7b6ZAPPEND
+Release:            1zimbra8.7b7ZAPPEND
 License:            IPL-1.0
 Source:             %{name}-%{version}.tar.gz
-BuildRequires:      zimbra-openldap-devel >= 2.5.17-1zimbra10.0b1ZAPPEND
+BuildRequires:      zimbra-openldap-devel >= 2.5.17-1zimbra10.0b2ZAPPEND
 BuildRequires:      zimbra-cyrus-sasl-devel >= 2.1.28-1zimbra8.7b4ZAPPEND
 BuildRequires:      zimbra-openssl-devel >= 3.5.1-1zimbra8.8b1ZAPPEND
 BuildRequires:      zimbra-mariadb-devel
-BuildRequires:      zimbra-lmdb-devel >= 2.5.17-1zimbra10.0b1ZAPPEND
+BuildRequires:      zimbra-lmdb-devel >= 2.5.17-1zimbra10.0b2ZAPPEND
 BuildRequires:      pcre-devel
 Requires:           pcre, libicu
-Requires:           zimbra-openldap-libs >= 2.5.17-1zimbra10.0b1ZAPPEND, zimbra-mta-base
+Requires:           zimbra-openldap-libs >= 2.5.17-1zimbra10.0b2ZAPPEND, zimbra-mta-base
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b4ZAPPEND, zimbra-mariadb
-Requires:           zimbra-lmdb-libs >= 2.5.17-1zimbra10.0b1ZAPPEND, zimbra-openssl-libs >= 3.5.1-1zimbra8.8b1ZAPPEND
+Requires:           zimbra-lmdb-libs >= 2.5.17-1zimbra10.0b2ZAPPEND, zimbra-openssl-libs >= 3.5.1-1zimbra8.8b1ZAPPEND
 Patch0:             postfix-main-cf-zimbra.patch
 Patch1:             stop-warning.patch
 Patch2:             postfix-ldap.patch
@@ -27,6 +27,8 @@ The Zimbra Postfix build
 %define debug_package %{nil}
 
 %changelog
+* Mon Apr 06 2026 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b7ZAPPEND
+- Updated openldap for ZBUG-5376
 * Wed Jul 16 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b6ZAPPEND
 - ZCS-17413, Upgraded OpenSSL to 3.5.1
 * Sat May 11 2024 Zimbra Packaging Services <packaging-devel@zimbra.com> - VERSION-1zimbra8.7b5ZAPPEND

--- a/zimbra/core-components/zimbra-core-components/debian/changelog
+++ b/zimbra/core-components/zimbra-core-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-core-components (10.1.7-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-5376, Updated core-components
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 06 Apr 2026 00:00:00 +0000
+
 zimbra-core-components (10.1.6-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * ZCS-17668, Upgrade Openjdk to 17.0.16

--- a/zimbra/core-components/zimbra-core-components/debian/control
+++ b/zimbra/core-components/zimbra-core-components/debian/control
@@ -11,7 +11,7 @@ Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-base, zimbra-os-requirements (>= 1.0.5-1zimbra8.7b1ZAPPEND), zimbra-perl (>= 1.0.9-1zimbra8.7b1ZAPPEND), zimbra-pflogsumm,
  zimbra-openssl (>= 3.5.1-1zimbra8.8b1ZAPPEND), zimbra-curl (>= 7.49.1-1zimbra8.7b4ZAPPEND), zimbra-cyrus-sasl (>= 2.1.28-1zimbra8.7b4ZAPPEND),
  zimbra-rsync (>= 3.4.1-1zimbra8.7b2ZAPPEND),
- zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-prepflog,
+ zimbra-mariadb-lib (>= 10.1.25-1zimbra8.7b3ZAPPEND), zimbra-openldap-client (>= 2.5.17-1zimbra10.0b2ZAPPEND), zimbra-prepflog,
  zimbra-tcmalloc-lib, zimbra-perl-innotop (>= 1.9.1-1zimbra8.7b4ZAPPEND), zimbra-openjdk (>= 17.0.16-1zimbra8.8b1ZAPPEND),
  zimbra-openjdk-cacerts (>= 1.0.12-1zimbra8.7b1ZAPPEND), zimbra-osl (>= 3.0.0-1zimbra10.0b1ZAPPEND), zimbra-amavis-logwatch,
  zimbra-postfix-logwatch (>= 1.40.03-1zimbra8.7b1ZAPPEND), zimbra-rrdtool

--- a/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
+++ b/zimbra/core-components/zimbra-core-components/rpm/SPECS/core-components.spec
@@ -1,6 +1,6 @@
 Summary:            Zimbra components for core package
 Name:               zimbra-core-components
-Version:            10.1.6
+Version:            10.1.7
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
 Requires:           zimbra-base, zimbra-os-requirements >= 1.0.5-1zimbra8.7b1ZAPPEND, zimbra-perl >= 1.0.9-1zimbra8.7b1ZAPPEND
@@ -8,7 +8,7 @@ Requires:           zimbra-pflogsumm
 Requires:           zimbra-openssl >= 3.5.1-1zimbra8.8b1ZAPPEND, zimbra-curl >= 7.49.1-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-cyrus-sasl >= 2.1.28-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-rsync >= 3.4.1-1zimbra8.7b2ZAPPEND
-Requires:           zimbra-mariadb-libs >= 10.1.25-1zimbra8.7b3ZAPPEND, zimbra-openldap-client >= 2.5.17-1zimbra10.0b1ZAPPEND
+Requires:           zimbra-mariadb-libs >= 10.1.25-1zimbra8.7b3ZAPPEND, zimbra-openldap-client >= 2.5.17-1zimbra10.0b2ZAPPEND
 Requires:           zimbra-osl >= 3.0.0-1zimbra10.0b1ZAPPEND
 Requires:           zimbra-prepflog, zimbra-tcmalloc-libs, zimbra-perl-innotop >= 1.9.1-1zimbra8.7b4ZAPPEND
 Requires:           zimbra-openjdk >= 17.0.16-1zimbra8.8b1ZAPPEND, zimbra-openjdk-cacerts >= 1.0.12-1zimbra8.7b1ZAPPEND
@@ -21,6 +21,8 @@ AutoReqProv:        no
 %define debug_package %{nil}
 
 %changelog
+* Mon Apr 06 2026 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.7
+- ZBUG-5376, Updated core-components
 * Mon Sep 15 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.6
 - ZCS-17668, Upgrade Openjdk to 17.0.16
 * Mon Sep 01 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.5

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-ldap-components (10.1.4-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-5376, Updated ldap-components
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 06 Apr 2026 00:00:00 +0000
+
 zimbra-ldap-components (10.1.3-1zimbra10.0b1ZAPPEND) unstable; urgency=medium
 
   * ZCS-17668, Upgrade Openjdk to 17.0.16

--- a/zimbra/ldap-components/zimbra-ldap-components/debian/control
+++ b/zimbra/ldap-components/zimbra-ldap-components/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: zimbra-ldap-components
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
- zimbra-ldap-base, zimbra-lmdb (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openldap-server (>= 2.5.17-1zimbra10.0b1ZAPPEND), zimbra-openssl (>= 3.5.1-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.5.1-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 10.1.6-1zimbra10.0b1ZAPPEND)
+ zimbra-ldap-base, zimbra-lmdb (>= 2.5.17-1zimbra10.0b2ZAPPEND), zimbra-openldap-server (>= 2.5.17-1zimbra10.0b2ZAPPEND), zimbra-openssl (>= 3.5.1-1zimbra8.8b1ZAPPEND), zimbra-openssl-lib (>= 3.5.1-1zimbra8.8b1ZAPPEND), zimbra-core-components (>= 10.1.7-1zimbra10.0b1ZAPPEND)
 Description: Zimbra components for ldap package
  Zimbra ldap components pulls in all the packages used by
  zimbra-ldap

--- a/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
+++ b/zimbra/ldap-components/zimbra-ldap-components/rpm/SPECS/ldap-components.spec
@@ -1,12 +1,12 @@
 Summary:            Zimbra components for ldap package
 Name:               zimbra-ldap-components
-Version:            10.1.3
+Version:            10.1.4
 Release:            1zimbra10.0b1ZAPPEND
 License:            GPL-2
-Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.5.17-1zimbra10.0b1ZAPPEND
-Requires:           zimbra-openldap-server >= 2.5.17-1zimbra10.0b1ZAPPEND
+Requires:           zimbra-ldap-base, zimbra-lmdb >= 2.5.17-1zimbra10.0b2ZAPPEND
+Requires:           zimbra-openldap-server >= 2.5.17-1zimbra10.0b2ZAPPEND
 Requires:           zimbra-openssl >= 3.5.1-1zimbra8.8b1ZAPPEND, zimbra-openssl-libs >= 3.5.1-1zimbra8.8b1ZAPPEND
-Requires:           zimbra-core-components >= 10.1.6-1zimbra10.0b1ZAPPEND
+Requires:           zimbra-core-components >= 10.1.7-1zimbra10.0b1ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
 AutoReqProv:        no
@@ -18,6 +18,8 @@ Zimbra ldap components pulls in all the packages used by
 zimbra-ldap
 
 %changelog
+* Mon Apr 06 2026 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.4
+- ZBUG-5376, Updated ldap-components
 * Mon Sep 15 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.3
 - ZCS-17668, Upgrade Openjdk to 17.0.16
 * Mon Sep 01 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.2

--- a/zimbra/mta-components/zimbra-mta-components/debian/changelog
+++ b/zimbra/mta-components/zimbra-mta-components/debian/changelog
@@ -1,3 +1,9 @@
+zimbra-mta-components (10.1.5-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
+
+  * ZBUG-5376, updated mta-components
+
+ -- Zimbra Packaging Services <packaging-devel@zimbra.com>  Mon, 06 Apr 2026 00:00:00 +0000
+
 zimbra-mta-components (10.1.4-1zimbra8.8b1ZAPPEND) unstable; urgency=medium
 
   * ZCS-17850, Upgraded ClamAV to 1.4.3

--- a/zimbra/mta-components/zimbra-mta-components/debian/control
+++ b/zimbra/mta-components/zimbra-mta-components/debian/control
@@ -12,7 +12,7 @@ Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends},
  zimbra-clamav (>= 1.4.3-1zimbra8.8b4ZAPPEND),
  zimbra-clamav-db (>= 1.0.0-1zimbra8.7b3ZAPPEND), zimbra-cluebringer, zimbra-mariadb (>= 10.1.25-1zimbra8.7b3ZAPPEND),
  zimbra-opendkim (>= 2.10.3-1zimbra8.7b7ZAPPEND), zimbra-perl-mail-spamassassin (>= 4.0.1-1zimbra8.8b4ZAPPEND),
- zimbra-postfix (>= 3.6.14-1zimbra8.7b6ZAPPEND),
+ zimbra-postfix (>= 3.6.14-1zimbra8.7b7ZAPPEND),
  zimbra-spamassassin-rules (>= 1.0.0-1zimbra8.8b7ZAPPEND)
 Description: Zimbra components for MTA package
  Zimbra mta components pulls in all the packages used by

--- a/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
+++ b/zimbra/mta-components/zimbra-mta-components/rpm/SPECS/mta-components.spec
@@ -1,13 +1,13 @@
 Summary:            Zimbra components for MTA package
 Name:               zimbra-mta-components
-Version:            10.1.4
+Version:            10.1.5
 Release:            1zimbra8.8b1ZAPPEND
 License:            GPL-2
 Requires:           sqlite, zimbra-mta-base, zimbra-altermime, zimbra-amavisd >= 2.13.0-1zimbra8.7b2ZAPPEND
 Requires:           zimbra-clamav >= 1.4.3-1zimbra8.8b4ZAPPEND, zimbra-clamav-db >= 1.0.0-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-cluebringer, zimbra-mariadb >= 10.1.25-1zimbra8.7b3ZAPPEND
 Requires:           zimbra-opendkim >= 2.10.3-1zimbra8.7b7ZAPPEND, zimbra-perl-mail-spamassassin >= 4.0.1-1zimbra8.8b4ZAPPEND
-Requires:           zimbra-postfix >= 3.6.14-1zimbra8.7b6ZAPPEND
+Requires:           zimbra-postfix >= 3.6.14-1zimbra8.7b7ZAPPEND
 Requires:           zimbra-spamassassin-rules >= 1.0.0-1zimbra8.8b7ZAPPEND
 Packager:           Zimbra Packaging Services <packaging-devel@zimbra.com>
 Group:              Development/Languages
@@ -20,6 +20,8 @@ Zimbra mta components pulls in all the packages used by
 zimbra-mta
 
 %changelog
+* Mon Apr 06 2026 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.5
+- ZBUG-5376, updated mta-components
 * Wed Sep 10 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.4
 - ZCS-17850, Upgraded ClamAV to 1.4.3
 * Mon Jul 25 2025 Zimbra Packaging Services <packaging-devel@zimbra.com> - 10.1.3


### PR DESCRIPTION
**Issue:**
SHA256 and SSHA256 hashes generated by LDAP on RHEL9/Ubuntu22 systems are currently incorrect. This results in incorrect newly generated userPasswords, and authentication failure for valid SSHA256 hashed userPasswords generated by other systems (moved to R9 through migration/replication/etc. during OS upgrade process).

**Fix:**
Added `-fno-strict-aliasing` to the SHA2 module build flags to prevent unsafe compiler optimizations.